### PR TITLE
Added water bodies and removed toporama for canvec

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -85,7 +85,8 @@
   "expiredSecondaryLayer": "Timesteps for certain layers are no longer available. Time values have been updated.",
   "ApplyColor": "Apply color to basemap",
   "RevertColor": "Revert to original color",
-  "Overlays": "Special layers",
+  "Overlays": "Overlays",
   "Boundaries": "Add geopolitical boundaries overlay",
-  "Major_cities": "Add major cities overlay"
+  "Major_cities": "Add major cities overlay",
+  "Water_bodies": "Add water bodies overlay"
 }

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -86,7 +86,8 @@
   "expiredSecondaryLayer": "Des pas de temps pour certaines couches sélectionnées ne sont plus disponibles. Les informations temporelles ont été mises à jour.",
   "ApplyColor": "Appliquer la couleur au fond de carte",
   "RevertColor": "Remettre la couleur originale",
-  "Overlays": "Couches spéciales",
+  "Overlays": "Couches superposées",
   "Boundaries": "Superposer les limites de frontières géopolitiques",
-  "Major_cities": "Superposer les grandes villes"
+  "Major_cities": "Superposer les grandes villes",
+  "Water_bodies": "Superposer les délimitations des plans d'eau"
 }

--- a/src/store/modules/Layers.js
+++ b/src/store/modules/Layers.js
@@ -51,14 +51,21 @@ const state = {
   outputSize: null,
   overlays: {
     Boundaries: {
-      layers: "boundaries",
-      url: "http://wms.ess-ws.nrcan.gc.ca/wms/toporama_en",
+      layers:
+        "boundary_large_01,boundary_small,boundary_mid,boundary_large_02,boundary_large_03",
+      url: "https://maps.geogratis.gc.ca/wms/canvec_en",
       zIndex: 9998,
+      isShown: false,
+    },
+    Water_bodies: {
+      layers: "shoreline_small,shoreline_mid,shoreline_large",
+      url: "https://maps.geogratis.gc.ca/wms/canvec_en",
+      zIndex: 9997,
       isShown: false,
     },
     Major_cities: {
       layers: "places_small,places_mid,places_large",
-      url: "http://maps.geogratis.gc.ca/wms/canvec_en",
+      url: "https://maps.geogratis.gc.ca/wms/canvec_en",
       zIndex: 9999,
       isShown: false,
     },


### PR DESCRIPTION
Added water bodies overlay.
Since toporama was only http and not https, it needed to be changed. As such, even though they are very light and sometimes not very helpful,  canvec layers will now be used for all of the current overlays.