### PR TITLE
Bugfixes for 1.2 release

### DIFF
--- a/src/components/Animation/CreateAnimation.vue
+++ b/src/components/Animation/CreateAnimation.vue
@@ -168,10 +168,10 @@ export default {
         return `${firstDateSplit[0]}${firstDateSplit[1]}-${lastDateSplit[0]}${lastDateSplit[1]}`;
       } else {
         return (
-          firstDate.toISOString().split(".")[0].replace(" ", "") +
+          firstDate.toISOString().split(".")[0].replace(/[:-]/g, "") +
           "Z" +
           "-" +
-          lastDate.toISOString().split(".")[0].replace(" ", "") +
+          lastDate.toISOString().split(".")[0].replace(/[:-]/g, "") +
           "Z"
         );
       }

--- a/src/components/Animation/ExportAnimation.vue
+++ b/src/components/Animation/ExportAnimation.vue
@@ -45,8 +45,8 @@ export default {
     exportName() {
       let animationTitle = this.getAnimationTitle;
       if (animationTitle !== "") {
-        animationTitle = animationTitle.replace("^", "");
-        animationTitle = animationTitle.replace(",", ".");
+        animationTitle = animationTitle.replaceAll("^", "");
+        animationTitle = animationTitle.replaceAll(",", ".");
         animationTitle = animationTitle
           .normalize("NFD")
           .replace(/[\u0300-\u036f]/g, "");

--- a/src/components/Layers/ModelRunHandler.vue
+++ b/src/components/Layers/ModelRunHandler.vue
@@ -49,7 +49,7 @@ export default {
       this.item.getSource().updateParams({
         DIM_REFERENCE_TIME: this.getProperDateString(
           this.currentMR,
-          this.item.get("layerTimeStep")
+          this.item.get("layerDateFormat")
         ),
       });
       this.item.setProperties({

--- a/src/components/Map/MapCanvas.vue
+++ b/src/components/Map/MapCanvas.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script>
-import { Attribution, Control } from "ol/control";
+import { Attribution, Control, ScaleLine } from "ol/control";
 import OLImage from "ol/layer/Image";
 import TileLayer from "ol/layer/Tile";
 import Map from "ol/Map";
@@ -72,6 +72,10 @@ export default {
       this.map.updateSize();
     });
 
+    const scaleControl = new ScaleLine({
+      units: "metric",
+    });
+
     this.map = new Map({
       target: this.$refs["map"],
       layers: [this.osm],
@@ -81,7 +85,7 @@ export default {
         maxZoom: 12,
       }),
       pixelRatio: 1,
-      controls: [], // defaultControls({ attribution: true }),
+      controls: [scaleControl],
     });
 
     let attribution = new Attribution();
@@ -242,7 +246,7 @@ export default {
       });
 
       imageLayer.getSource().updateParams({
-        STYLES: imageLayer.get("currentStyle"),
+        STYLES: imageLayer.get("layerCurrentStyle"),
       });
 
       if (this.getActiveLegends.length === 0) {

--- a/src/components/Share/PermaLink.vue
+++ b/src/components/Share/PermaLink.vue
@@ -96,7 +96,9 @@ export default {
           this.getMapTimeSettings.SnappedLayer
             ? "1"
             : "0";
-        let isVisible = this.$mapLayers.arr[i].get("visible") ? "1" : "0";
+        let isVisible = this.$mapLayers.arr[i].get("layerVisibilityOn")
+          ? "1"
+          : "0";
         let layerStyle = "0";
         if (
           this.$mapLayers.arr[i].get("layerCurrentStyle") !==

--- a/src/components/Time/ExpiredTimestepManager.vue
+++ b/src/components/Time/ExpiredTimestepManager.vue
@@ -138,7 +138,7 @@ export default {
       let [start, end, step] = layerData.Dimension.Dimension_time.split("/");
       let extentDateArray = this.getDateArray(
         layerData.Dimension.Dimension_time
-      );
+      )[0];
       const newLayerIndex = this.findLayerIndex(
         this.getMapTimeSettings.Extent[this.getMapTimeSettings.DateIndex],
         extentDateArray,
@@ -151,7 +151,7 @@ export default {
         layerModelRuns:
           layerData.Dimension.Dimension_ref_time === ""
             ? null
-            : this.getDateArray(layerData.Dimension.Dimension_ref_time),
+            : this.getDateArray(layerData.Dimension.Dimension_ref_time)[0],
         layerStartTime: new Date(start),
         layerEndTime: new Date(end),
         layerTimeStep: step,

--- a/src/components/Time/TimeSlider.vue
+++ b/src/components/Time/TimeSlider.vue
@@ -21,11 +21,15 @@
       <v-col>
         <v-range-slider
           class="range_slider"
+          v-model="datetimeRangeSlider"
           :disabled="isAnimating"
           :min="0"
           :max="getMapTimeSettings.Extent.length - 1"
-          v-model="datetimeRangeSlider"
           :rules="[rangeValuesNotSame]"
+          :color="hideRangeSlider"
+          :thumb-color="hideRangeSlider"
+          :track-color="hideRangeSlider"
+          :track-fill-color="hideRangeSlider"
           hide-details
           @end="changeDisplayedTime"
         ></v-range-slider>
@@ -107,6 +111,14 @@ export default {
   computed: {
     ...mapGetters("Layers", ["getDatetimeRangeSlider", "getMapTimeSettings"]),
     ...mapState("Layers", ["isAnimating"]),
+    currentTime: {
+      get() {
+        return this.getMapTimeSettings.DateIndex;
+      },
+      set(newDateIndex) {
+        this.$store.dispatch("Layers/setMapTimeIndex", newDateIndex);
+      },
+    },
     datetimeRangeSlider: {
       get() {
         return this.getDatetimeRangeSlider;
@@ -115,13 +127,15 @@ export default {
         this.$store.commit("Layers/setDatetimeRangeSlider", dateRange);
       },
     },
-    currentTime: {
-      get() {
-        return this.getMapTimeSettings.DateIndex;
-      },
-      set(newDateIndex) {
-        this.$store.dispatch("Layers/setMapTimeIndex", newDateIndex);
-      },
+    hideRangeSlider() {
+      if (
+        this.getMapTimeSettings.Extent !== null &&
+        this.getMapTimeSettings.Extent.length === 1
+      ) {
+        return "rgba(0, 0, 0, 0)";
+      } else {
+        return undefined;
+      }
     },
   },
 };

--- a/src/mixins/datetimeManipulations.js
+++ b/src/mixins/datetimeManipulations.js
@@ -63,11 +63,19 @@ export default {
         }
       }
       if (dateIndex === null) {
-        dateIndex = this.findLayerIndex(
-          timeLayers[0].get("layerDefaultTime"),
-          timeLayers[0].get("layerDateArray"),
-          timeLayers[0].get("layerTimeStep")
-        );
+        if (snappedLayer !== null) {
+          dateIndex = this.findLayerIndex(
+            snappedLayer.get("layerDefaultTime"),
+            arrayCombine,
+            snappedLayer.get("layerTimeStep")
+          );
+        } else {
+          dateIndex = this.findLayerIndex(
+            timeLayers[0].get("layerDefaultTime"),
+            arrayCombine,
+            timeLayers[0].get("layerTimeStep")
+          );
+        }
         if (timestep === this.getMapTimeSettings.Step) {
           const currentDateIndex = this.findLayerIndex(
             this.getMapTimeSettings.Extent[this.getMapTimeSettings.DateIndex],
@@ -138,6 +146,14 @@ export default {
       let dateArray = new Array();
       if (dateRange.includes("/")) {
         var [startDateStr, endDateStr, interval] = dateRange.split("/");
+        var format;
+        if (/^\d{4}-([0]\d|1[0-2])$/.test(startDateStr)) {
+          format = "month";
+        } else if (/^\d{4}$/.test(startDateStr)) {
+          format = "year";
+        } else {
+          format = "ISO";
+        }
         let startDate = new Date(startDateStr);
         let endDate = new Date(endDateStr);
         let nextDate = parseDuration(interval).add;
@@ -154,12 +170,12 @@ export default {
           .split(",")
           .forEach((dateString) => dateArray.push(new Date(dateString)));
       }
-      return dateArray;
+      return [dateArray, format];
     },
-    getProperDateString(date, timestep) {
-      if (timestep === "P1Y") {
+    getProperDateString(date, dateFormat) {
+      if (dateFormat === "year") {
         return date.toISOString().split("-")[0];
-      } else if (timestep === "P1M") {
+      } else if (dateFormat === "month") {
         let dateSplit = date.toISOString().split("-");
         let year = dateSplit[0];
         let month = dateSplit[1];

--- a/src/store/modules/Layers.js
+++ b/src/store/modules/Layers.js
@@ -205,7 +205,7 @@ const mutations = {
     state.timeFormat = newTimeFormat;
   },
   setAnimationTitle: (state, title) => {
-    state.animationTitle = title;
+    state.animationTitle = title === null ? "" : title;
   },
   setWmsSourceURL: (state, newWmsSource) => {
     state.currentWmsSource = newWmsSource;


### PR DESCRIPTION
Fixed:
- Date format inside animation filename;
- Monthly and Yearly now work for GeoMet-Weather as well;
- Visibility of the layer from the permalink is now correct;
- Adding a new layer from a different timestep will be correctly set invisible if the current map time is out of bounds;
- Snapped layer logic reduced when adding a new time layer;
- Layers with start time the same as end time (like PT0H) now work properly;
- animation won't fail if you cleared title prior;
- Date now changed to snappedLayer default time when map time changes;
- Fixed legend not being applied when coming from permalink.

Added:
- Scale line on the map.