### PR TITLE
remove use of lang query param when fetching dimensions from GetCapa

### DIFF
--- a/src/components/Layers/LayerTree.vue
+++ b/src/components/Layers/LayerTree.vue
@@ -202,7 +202,6 @@ export default {
             service: "WMS",
             version: "1.3.0",
             request: "GetCapabilities",
-            LANG: this_.$i18n.locale,
             LAYER: layer.Name,
             t: new Date().getTime(),
           },

--- a/src/components/Time/ExpiredTimestepManager.vue
+++ b/src/components/Time/ExpiredTimestepManager.vue
@@ -119,7 +119,6 @@ export default {
           service: "WMS",
           version: "1.3.0",
           request: "GetCapabilities",
-          LANG: this.$i18n.locale,
           LAYER: layer.get("layerName"),
           t: new Date().getTime(),
         },


### PR DESCRIPTION
This MR ensure that the `LANG` query parameter is not passed when querying the GetCapabilities document for temporal dimensions. This ensures that GetCapabilities and GetMap requests made via AniMet are always made to the same mapfile.


CC @PhilippeTh @kngai 