### PR TITLE
Added possibility to add custom WMS sources more easily

### DIFF
--- a/scripts/generate_trees_layers_list.py
+++ b/scripts/generate_trees_layers_list.py
@@ -26,7 +26,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # =================================================================
+import glob
 import json
+import os
 
 from owslib.wms import WebMapService
 
@@ -76,13 +78,25 @@ langs = ["en", "fr"]
 with open("wms_sources_configs.json") as f:
     wmsSources = json.load(f)
 
+trees_files = glob.glob("../src/assets/trees/tree_*.js")
+layers_en_files = glob.glob("../src/locales/en/layers_*.json")
+layers_fr_files = glob.glob("../src/locales/fr/layers_*.json")
+
+file_list = trees_files + layers_en_files + layers_fr_files
+
+for file_path in file_list:
+    os.remove(file_path)
+
 for name, params in wmsSources.items():
     name = name.lower()
     for lang in langs:
-
+        if "?" in params["url"]:
+            base_url = f"{params['url']}&lang={lang}"
+        else:
+            base_url = f"{params['url']}?lang={lang}"
         try:
             wms = WebMapService(
-                f"{params['url']}?lang={lang}", version=params["version"]
+                base_url, version=params["version"]
             )
         except Exception as e:
             raise SystemExit(e)

--- a/src/assets/trees/index.js
+++ b/src/assets/trees/index.js
@@ -1,0 +1,9 @@
+const files = require.context("./", false, /\.js$/);
+const modules = {};
+
+files.keys().forEach((key) => {
+  if (key === "./index.js") return;
+  modules[key.replace(/(\.\/|\.js)/g, "")] = files(key).default;
+});
+
+export default modules;

--- a/src/components/Layers/StyleHandler.vue
+++ b/src/components/Layers/StyleHandler.vue
@@ -9,7 +9,7 @@
             v-bind="attrs"
             v-on="{ ...tooltip, ...menu }"
             icon
-            :disabled="isAnimating"
+            :disabled="isAnimating || item.get('layerStyles').length === 0"
             hide-details
             class="style-selector"
           >

--- a/src/components/Map/LegendControls.vue
+++ b/src/components/Map/LegendControls.vue
@@ -41,10 +41,13 @@ export default {
       let layer = this.$mapLayers.arr.find(
         (l) => l.get("layerName") === layerName
       );
-      const wmsSource = layer.get("source")["url_"];
-      const currentStyle = layer.get("layerCurrentStyle");
-      let r = `${wmsSource}?version=1.3.0&service=WMS&request=GetLegendGraphic&sld_version=1.1.0&layer=${layerName}&format=image/png&STYLE=${currentStyle}`;
-      return r;
+      if (layer.get("layerStyles").length === 0) {
+        return null;
+      }
+      return layer
+        .get("layerStyles")
+        .find((style) => style.Name === layer.get("layerCurrentStyle"))
+        .LegendURL;
     },
     dragMouseDown: function (event) {
       if (this.isAnimating) {
@@ -90,6 +93,8 @@ export default {
   overflow: auto;
   top: 20px;
   left: 20px;
+  max-width: 100%;
+  max-height: 100%;
 }
 
 .resizable img {

--- a/src/components/Map/LegendSelector.vue
+++ b/src/components/Map/LegendSelector.vue
@@ -53,7 +53,10 @@ export default {
     ...mapGetters("Layers", ["getActiveLegends"]),
     ...mapState("Layers", ["isAnimating"]),
     getItemsList() {
-      return this.$mapLayers.arr.slice().map((l) => l.get("layerName"));
+      return this.$mapLayers.arr
+        .slice()
+        .filter((l) => l.get("layerStyles").length !== 0)
+        .map((l) => l.get("layerName"));
     },
   },
   methods: {

--- a/src/components/Map/MapCanvas.vue
+++ b/src/components/Map/MapCanvas.vue
@@ -242,6 +242,8 @@ export default {
       imageLayer.setProperties({
         layerCurrentStyle: Object.hasOwn(layerData, "currentStyle")
           ? layerData.currentStyle
+          : layerData.Style.length === 0
+          ? null
           : layerData.Style[0].Name,
         layerDateIndex: 0,
         layerIsTemporal: layerData.isTemporal,

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -66,6 +66,7 @@
   "SnapLayerToExtent": "Apply temporal extent and interval to animation.",
   "SnappedLayer": "Temporal extent and interval currently applied to animation.",
   "SocialWeatherHashtags": "weather,opendata",
+  "StyleError": "The WMS request failed with the style included in the request. The layer's style has thus been reset to the default style and may not match with the displayed legend.",
   "TimestepsDropdown": "Interval",
   "UnhandledError": "An unhandled error was encountered. The layer had to be removed.",
   "UserDoc": "User documentation",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -66,6 +66,7 @@
   "SnapLayerToExtent": "Appliquer l'étendue temporelle et l'intervalle à l'animation.",
   "SnappedLayer": "Étendue temporelle et intervalle appliqués à l'animation.",
   "SocialWeatherHashtags": "meteo,donneesouvertes",
+  "StyleError": "La requête WMS n'a pas fonctionné en incluant le style dans la requête. Le style de la couche a donc été réinitialisé au style par défaut et peut ne pas correspondre à la légende affichée.",
   "TimestepsDropdown": "Pas de temps",
   "UnhandledError": "Une erreur non répertoriée a été rencontrée. La couche a dû être retirée.",
   "UserDoc": "Documentation utilisateur",

--- a/src/store/modules/Layers.js
+++ b/src/store/modules/Layers.js
@@ -1,7 +1,4 @@
-import treeEn_weather from "../../assets/trees/tree_en_weather";
-import treeFr_weather from "../../assets/trees/tree_fr_weather";
-import treeEn_climate from "../../assets/trees/tree_en_climate";
-import treeFr_climate from "../../assets/trees/tree_fr_climate";
+import { default as layerTrees } from "../../assets/trees";
 import wmsSources from "../../../scripts/wms_sources_configs.json";
 
 const state = {
@@ -15,14 +12,14 @@ const state = {
   isAnimating: false,
   lang: "en",
   activeLegendsList: [],
-  layerTreeItemsEn: [
-    treeEn_weather.tree_en_weather,
-    treeEn_climate.tree_en_climate,
-  ],
-  layerTreeItemsFr: [
-    treeFr_weather.tree_fr_weather,
-    treeFr_climate.tree_fr_climate,
-  ],
+  layerTreeItemsEn: Object.keys(wmsSources).map((key) => {
+    const treeName = "tree_en_" + key.toLowerCase();
+    return layerTrees[treeName][treeName];
+  }),
+  layerTreeItemsFr: Object.keys(wmsSources).map((key) => {
+    const treeName = "tree_fr_" + key.toLowerCase();
+    return layerTrees[treeName][treeName];
+  }),
   mapTimeSettings: {
     SnappedLayer: null,
     Step: null,


### PR DESCRIPTION
- Generation script now deletes trees en/fr and layers en/fr files before creating new ones so that you don't keep old configs even when you change them;
- Imports are now automated inside Layers.js so that you need only run the generate script and the imports will be done automatically;
- Added index.js file that exports all trees so that they can then be imported in a batch by Layers.js;
- Added an error case where the WMS cannot be querried with the legend name but is still queriable;
- Added an error case where a layer could be in the layerTree's added list but not inside the layers list;
- Added a case where the URL for the config needed to include special parameters like `https://eccharts.ecmwf.int/wms/?token=public` that won't work if `?token=public` is not present (now you can just put it directly in the URL of the config);
- Added an error case where a layer doesn't have any legend;
- Added a case where the layer's legend would be way to big (still is too big but if it's bigger than the map there's a scrollbar in the legend);
- Legend selector is now disabled if the styles list is empty;
- Made the legend be queried from the legendURL rather than hardcoding it like it was before;
- Added the layerName inside the XPath for querying the xml for cases where you cannot specify the `layers=` parameter for the getCapabilities.