### PR TITLE
Fixed hardcoded path in Layers.js and icons overlapped when layer names are too long

### DIFF
--- a/src/components/Layers/LayerConfiguration.vue
+++ b/src/components/Layers/LayerConfiguration.vue
@@ -144,6 +144,7 @@ export default {
 }
 .content {
   min-height: 96px;
+  max-width: 100%;
 }
 .list-enter,
 .list-leave-to {

--- a/src/components/Layers/LayerTree.vue
+++ b/src/components/Layers/LayerTree.vue
@@ -185,10 +185,10 @@ export default {
         const api = axios.create({
           baseURL: source,
           params: {
-            service: "WMS",
-            version: "1.3.0",
-            request: "GetCapabilities",
-            LAYER: layer.Name,
+            SERVICE: "WMS",
+            VERSION: "1.3.0",
+            REQUEST: "GetCapabilities",
+            LAYERS: layer.Name,
             t: new Date().getTime(),
           },
         });

--- a/src/components/Layers/StyleHandler.vue
+++ b/src/components/Layers/StyleHandler.vue
@@ -45,7 +45,7 @@ export default {
       layer.setProperties({
         layerCurrentStyle: styleName,
       });
-      layer.getSource().updateParams({ STYLE: styleName });
+      layer.getSource().updateParams({ STYLES: styleName });
     },
   },
   computed: {

--- a/src/components/Map/MapCanvas.vue
+++ b/src/components/Map/MapCanvas.vue
@@ -275,7 +275,7 @@ export default {
       });
 
       imageLayer.getSource().updateParams({
-        STYLE: imageLayer.get("layerCurrentStyle"),
+        STYLES: imageLayer.get("layerCurrentStyle"),
       });
 
       if (this.getActiveLegends.length === 0) {

--- a/src/components/Time/ExpiredTimestepManager.vue
+++ b/src/components/Time/ExpiredTimestepManager.vue
@@ -168,7 +168,7 @@ export default {
           "code" in attrs &&
           attrs["code"].nodeValue === "StyleNotDefined"
         ) {
-          layer.getSource().updateParams({ STYLE: null });
+          layer.getSource().updateParams({ STYLES: null });
           this.expiredSnackBarMessage = this.$t("StyleError");
           this.notifyExtentRebuilt = true;
           this.errorLayersList = this.errorLayersList.filter(
@@ -202,10 +202,10 @@ export default {
       const api = axios.create({
         baseURL: layer.get("source")["url_"],
         params: {
-          service: "WMS",
-          version: "1.3.0",
-          request: "GetCapabilities",
-          LAYER: layer.get("layerName"),
+          SERVICE: "WMS",
+          VERSION: "1.3.0",
+          REQUEST: "GetCapabilities",
+          LAYERS: layer.get("layerName"),
           t: new Date().getTime(),
         },
       });

--- a/src/store/modules/Layers.js
+++ b/src/store/modules/Layers.js
@@ -3,7 +3,7 @@ import wmsSources from "../../../scripts/wms_sources_configs.json";
 
 const state = {
   animationTitle: "",
-  currentWmsSource: "https://geo.weather.gc.ca/geomet",
+  currentWmsSource: Object.values(wmsSources)[0]["url"],
   datetimeRangeSlider: [null, null],
   exportStyle: null,
   extent: null,


### PR DESCRIPTION
- Fixed hardcoded path in Layers.js so that won't trip the configs;
- Fixed css so the the icons don't disappear when screen is shrunk;
- Changed parameter names to match WMS specifications.