### PR TITLE
Added legend differentiation and replay button

### DIFF
--- a/src/components/Map/LegendControls.vue
+++ b/src/components/Map/LegendControls.vue
@@ -6,10 +6,12 @@
     v-if="getActiveLegends.length !== 0"
   >
     <img
-      :name="name"
       :id="name"
-      crossorigin="anonymous"
+      :name="name"
       :src="getMapLegendURL(name)"
+      :style="{ border: getStyle }"
+      :title="name"
+      crossorigin="anonymous"
     />
   </div>
 </template>
@@ -30,10 +32,22 @@ export default {
     };
   },
   computed: {
-    ...mapGetters("Layers", ["getActiveLegends"]),
+    ...mapGetters("Layers", ["getColorBorder", "getActiveLegends"]),
     ...mapState("Layers", ["isAnimating"]),
+    getStyle() {
+      if (this.getColorBorder) {
+        return `2px solid ${this.getLegendStyle()}`;
+      }
+      return "none";
+    },
   },
   methods: {
+    getLegendStyle() {
+      const legendRGB = this.$mapLayers.arr
+        .find((l) => l.get("layerName") === this.name)
+        .get("legendColor");
+      return `rgb(${legendRGB.r}, ${legendRGB.g}, ${legendRGB.b})`;
+    },
     getMapLegendURL(layerName) {
       if (layerName === null) {
         return null;

--- a/src/components/Map/LegendSelector.vue
+++ b/src/components/Map/LegendSelector.vue
@@ -2,7 +2,7 @@
   <v-menu
     top
     offset-y
-    nudge-bottom="10"
+    nudge-bottom="0"
     nudge-left="5"
     content-class="white black--text"
   >
@@ -22,6 +22,12 @@
     </template>
     <v-container @click.stop>
       {{ $t("LegendSelector") }}
+      <v-switch
+        hide-details
+        class="mt-0 pt-0"
+        :label="$t('ColorBorder')"
+        v-model="colorBorder"
+      ></v-switch>
       <v-checkbox
         v-for="(name, index) in getItemsList"
         :key="index"
@@ -29,6 +35,7 @@
         :input-value="getActiveLegends.includes(name)"
         hide-details
         class="pl-12 font-weight-medium"
+        :color="legendStyle(name)"
         @change="toggleLegends(name, $event)"
       >
         <template v-slot:label>
@@ -50,7 +57,7 @@ export default {
     };
   },
   computed: {
-    ...mapGetters("Layers", ["getActiveLegends"]),
+    ...mapGetters("Layers", ["getColorBorder", "getActiveLegends"]),
     ...mapState("Layers", ["isAnimating"]),
     getItemsList() {
       return this.$mapLayers.arr
@@ -58,8 +65,25 @@ export default {
         .filter((l) => l.get("layerStyles").length !== 0)
         .map((l) => l.get("layerName"));
     },
+    colorBorder: {
+      get() {
+        return this.getColorBorder;
+      },
+      set(state) {
+        this.$store.dispatch("Layers/setColorBorder", state);
+      },
+    },
   },
   methods: {
+    legendStyle(name) {
+      if (this.colorBorder) {
+        const legendRGB = this.$mapLayers.arr
+          .find((l) => l.get("layerName") === name)
+          .get("legendColor");
+        return `rgb(${legendRGB.r}, ${legendRGB.g}, ${legendRGB.b})`;
+      }
+      return undefined;
+    },
     toggleLegends(name, on) {
       if (on) {
         this.$store.dispatch("Layers/addActiveLegend", name);

--- a/src/components/Map/MapCanvas.vue
+++ b/src/components/Map/MapCanvas.vue
@@ -261,7 +261,9 @@ export default {
         layerVisibilityOn: Object.hasOwn(layerData, "visible")
           ? layerData.visible
           : true,
+        legendColor: this.randomHSVtoRGB(),
       });
+
       if (layerData.isTemporal) {
         imageLayer.setProperties({
           layerModelRuns: null,
@@ -299,6 +301,42 @@ export default {
         this.map.addLayer(imageLayer);
       }
     },
+    randomHSVtoRGB() {
+      var r, g, b, i, f, p, q, t;
+      this.h += this.golden_ratio_conjugate;
+      this.h %= 1;
+
+      i = Math.floor(this.h * 6);
+      f = this.h * 6 - i;
+      p = this.v * (1 - this.s);
+      q = this.v * (1 - f * this.s);
+      t = this.v * (1 - (1 - f) * this.s);
+      switch (i % 6) {
+        case 0:
+          (r = this.v), (g = t), (b = p);
+          break;
+        case 1:
+          (r = q), (g = this.v), (b = p);
+          break;
+        case 2:
+          (r = p), (g = this.v), (b = t);
+          break;
+        case 3:
+          (r = p), (g = q), (b = this.v);
+          break;
+        case 4:
+          (r = t), (g = p), (b = this.v);
+          break;
+        case 5:
+          (r = this.v), (g = p), (b = q);
+          break;
+      }
+      return {
+        r: Math.round(r * 255),
+        g: Math.round(g * 255),
+        b: Math.round(b * 255),
+      };
+    },
   },
   computed: {
     ...mapState("Layers", ["isAnimating"]),
@@ -312,6 +350,10 @@ export default {
   },
   data() {
     return {
+      golden_ratio_conjugate: (1 + Math.sqrt(5)) / 2 - 1,
+      h: Math.random(),
+      s: 0.95,
+      v: 0.75,
       loading: false,
       osm: new TileLayer({ source: new OSM() }),
       map: null,

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -12,6 +12,7 @@
   "Close": "Close",
   "CMD_WMS": "CMD-WMS",
   "Colon": ":",
+  "ColorBorder": "Display legend color border",
   "DarkBasemapSwitch": "Dark basemap",
   "DocumentationURL": "https://eccc-msc.github.io/open-data/msc-animet/readme_en/",
   "ErrorNoTimeLayer": "Please add a temporal layer",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -12,6 +12,7 @@
   "Close": "Fermer",
   "CMD_WMS": "CMD-WMS",
   "Colon": " :",
+  "ColorBorder": "Afficher la bordure des légendes en couleur",
   "DarkBasemapSwitch": "Carte foncée",
   "DocumentationURL": "https://eccc-msc.github.io/open-data/msc-animet/readme_fr/",
   "ErrorNoTimeLayer": "Veuillez ajouter une couche temporelle",

--- a/src/store/modules/Layers.js
+++ b/src/store/modules/Layers.js
@@ -3,6 +3,7 @@ import wmsSources from "../../../scripts/wms_sources_configs.json";
 
 const state = {
   animationTitle: "",
+  colorBorder: false,
   currentWmsSource: Object.values(wmsSources)[0]["url"],
   datetimeRangeSlider: [null, null],
   exportStyle: null,
@@ -62,6 +63,9 @@ const state = {
 };
 
 const getters = {
+  getColorBorder: (state) => {
+    return state.colorBorder;
+  },
   getGeoMetTreeItems: (state) => {
     if (state.lang === "en") {
       return state.layerTreeItemsEn;
@@ -152,6 +156,9 @@ const mutations = {
       (l) => l !== legend
     );
   },
+  setColorBorder: (state, newStatus) => {
+    state.colorBorder = newStatus;
+  },
   setMP4URL: (state, URL) => {
     state.MP4URL = URL;
   },
@@ -230,6 +237,9 @@ const actions = {
   },
   removeActiveLegend({ commit }, payload) {
     commit("removeActiveLegend", payload);
+  },
+  setColorBorder({ commit }, payload) {
+    commit("setColorBorder", payload);
   },
   setLang({ commit }, payload) {
     commit("setLang", payload);

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -108,5 +108,3 @@ export default {
   },
 };
 </script>
-
-<style scoped></style>


### PR DESCRIPTION
Legend differentiation:
- Added switch inside legend menu to toggle color border;
- Color border is now applied with a random color to each legend when a layer is added. Will only be displayed is the switch is on;
- Checkbox for the layer legend selection will be the same color as the legend's border;
- Border also appears in animation and a bullet of the same color will appear on the left of the layer's name in the layer list;
- Used HSV to stay within the same color range and not give colors like flashy green that would be annoying to look at;
- Changed "nudge-bottom" to 0 to move the legend selector completely over the button rather than overlapping the button a bit.

Replay button:
- Added a lock for the PlayPause function to prevent spamming and sending multiple play events at once (bugfix);
- Replay button appears when you're at the last timestep instead of showing a greyed out disabled play button.