### PR TITLE
Fixed animation with white background and corrected error case

### DIFF
--- a/src/components/Animation/CreateAnimation.vue
+++ b/src/components/Animation/CreateAnimation.vue
@@ -370,6 +370,8 @@ export default {
       mapCanvas.width = mapCanvasUI.offsetWidth; //size[0]
       mapCanvas.height = mapCanvasUI.offsetHeight; //size[1]
       let mapContext = mapCanvas.getContext("2d");
+      mapContext.fillStyle = "white";
+      mapContext.fillRect(0, 0, mapCanvas.width, mapCanvas.height);
       Array.prototype.forEach.call(
         document.querySelectorAll(".ol-layer canvas"),
         function (canvas) {

--- a/src/components/Time/ExpiredTimestepManager.vue
+++ b/src/components/Time/ExpiredTimestepManager.vue
@@ -142,6 +142,9 @@ export default {
           let newExtent = layer
             .get("layerDateArray")
             .toSpliced(layer.get("layerDateIndex"), 1);
+          if (newExtent.length === 0) {
+            throw new Error("All of the layer's timesteps are broken");
+          }
           let newDefaultTimeIndex = this.findLayerIndex(
             layer.get("layerDefaultTime"),
             newExtent,


### PR DESCRIPTION
- Animation background now fully white instead of black when making it invisible;
- Added small error case for when and entire layer's timesteps are missing.