### PR TITLE
Last minute fixes

### DIFF
--- a/src/components/Animation/AnimationRectangle.vue
+++ b/src/components/Animation/AnimationRectangle.vue
@@ -65,7 +65,10 @@ export default {
       }
     },
     getInfoCanvas() {
-      if (this.$mapLayers.arr.length !== 0) {
+      if (
+        this.$mapLayers.arr.length !== 0 &&
+        this.getMapTimeSettings.Extent !== null
+      ) {
         this.$root.$emit("setAnimationTitle");
         let infoCanvas = document.createElement("canvas");
         let ctx = infoCanvas.getContext("2d");

--- a/src/components/Animation/CreateAnimation.vue
+++ b/src/components/Animation/CreateAnimation.vue
@@ -130,7 +130,9 @@ export default {
         let firstDateSplit = firstDate.toISOString().split("-");
         return `${firstDateSplit[0]}${firstDateSplit[1]}`;
       } else {
-        return firstDate.toISOString().split(".")[0].replace(/[:-]/g, "") + "Z";
+        return (
+          firstDate.toISOString().split(":00.000")[0].replace(/[:-]/g, "") + "Z"
+        );
       }
     },
     trackCreateMP4() {

--- a/src/components/Time/TimeControls.vue
+++ b/src/components/Time/TimeControls.vue
@@ -467,7 +467,7 @@ export default {
   border-radius: 20px;
   max-width: 1200px;
 }
-@media (min-width: 1051px) {
+@media (min-width: 1121px) {
   .collapsed {
     pointer-events: auto;
     border-radius: 4px 4px 0 0;


### PR DESCRIPTION
- Fixed time controls collapse invisible between 1051 and 1120px
- Fixed error in the terminal when animation rectangle would try to create the preview when no time layers were there
- Removed seconds from the output animation time