### PR TITLE
Multiple bugfixes and config change for chrome

### DIFF
--- a/src/components/Animation/CreateAnimation.vue
+++ b/src/components/Animation/CreateAnimation.vue
@@ -299,12 +299,15 @@ export default {
     },
     handleCancelExpired() {
       this.cancelExpired = true;
+      this.cancelAnimationCreation();
     },
     restoreState(initialState = null) {
-      this.$store.dispatch(
-        "Layers/setMapTimeIndex",
-        initialState === null ? 0 : initialState
-      );
+      if (initialState === null) {
+        initialState = 0;
+      } else if (initialState > this.datetimeRangeSlider[1]) {
+        initialState = this.datetimeRangeSlider[1];
+      }
+      this.$store.dispatch("Layers/setMapTimeIndex", initialState);
 
       this.$store.dispatch("Layers/setMP4Percent", 0);
       this.$store.dispatch("Layers/setMP4CreateFlag", false);

--- a/src/components/Map/MapCanvas.vue
+++ b/src/components/Map/MapCanvas.vue
@@ -416,7 +416,7 @@ export default {
       );
 
       if (!allExist) {
-        setTimeout(waitForElements, 250);
+        setTimeout(this.waitForElements, 250);
       } else {
         return;
       }

--- a/src/components/Time/ErrorManager.vue
+++ b/src/components/Time/ErrorManager.vue
@@ -183,9 +183,8 @@ export default {
         ) {
           this.$root.$emit("cancelExpired");
           this.expiredTimestepList.push(layer.get("layerTimeStep"));
-          let newExtent = layer
-            .get("layerDateArray")
-            .toSpliced(layer.get("layerDateIndex"), 1);
+          let newExtent = [...layer.get("layerDateArray")];
+          newExtent.splice(layer.get("layerDateIndex"), 1);
           if (newExtent.length === 0) {
             throw new Error("All of the layer's timesteps are broken");
           }

--- a/vue.config.js
+++ b/vue.config.js
@@ -13,6 +13,7 @@ module.exports = defineConfig({
     });
   },
   configureWebpack: {
+    devtool: "source-map",
     plugins: [new NodePolyfillPlugin()],
     resolve: {
       fallback: {


### PR DESCRIPTION
- Fixed a bug where a method wasn't referenced with `this.`
- Fixed a bug where layer would crash on firefox on missing timestep rather than removing the timestep
- Fixed a bug where animation events would duplicate on missing timestep rather than end and restart (old event never stopped so the method was trying to start from the beginning and from where it crashed at the same time)
- Fixed a bug where "initialState" would be further than the last timestep of the extent because missing timesteps were removed
- Added special config to see files appear on chrome again