### PR TITLE
Which layer legends are active is now remembered as part of the permalink

### DIFF
--- a/src/components/GlobalConfigs/LegendSelector.vue
+++ b/src/components/GlobalConfigs/LegendSelector.vue
@@ -128,6 +128,7 @@ export default {
       } else {
         this.$store.dispatch("Layers/removeActiveLegend", name);
       }
+      this.$root.$emit("updatePermalink");
     },
   },
 };
@@ -138,11 +139,13 @@ export default {
   min-width: 400px;
   max-width: 600px;
 }
+
 @media (max-width: 400px) {
   .selector-menu {
     min-width: 0;
   }
 }
+
 #legendMapSelector {
   pointer-events: auto;
   z-index: 4;

--- a/src/components/GlobalConfigs/Share/PermaLink.vue
+++ b/src/components/GlobalConfigs/Share/PermaLink.vue
@@ -68,6 +68,7 @@ export default {
   },
   computed: {
     ...mapGetters("Layers", [
+      "getActiveLegends",
       "getExtent",
       "getMapTimeSettings",
       "getPermalink",
@@ -100,6 +101,7 @@ export default {
           permalinktemp += "layers=";
           const numLayers = this.$mapLayers.arr.length;
           for (let i = 0; i < numLayers; i++) {
+            let layerName = this.$mapLayers.arr[i].get("layerName");
             let layerOpacity = this.$mapLayers.arr[i].get("opacity").toString();
             let isSnapped =
               this.$mapLayers.arr[i].get("layerName") ===
@@ -117,8 +119,11 @@ export default {
             ) {
               layerStyle = this.$mapLayers.arr[i].get("layerCurrentStyle");
             }
+            let legendDisplayed = this.getActiveLegends.includes(layerName)
+              ? "1"
+              : "0";
             permalinktemp +=
-              this.$mapLayers.arr[i].get("layerName") +
+              layerName +
               ";" +
               layerOpacity +
               ";" +
@@ -126,7 +131,9 @@ export default {
               ";" +
               isVisible +
               ";" +
-              layerStyle;
+              layerStyle +
+              ";" +
+              legendDisplayed;
 
             if (i < this.$mapLayers.arr.length - 1) {
               permalinktemp += ",";
@@ -161,7 +168,9 @@ export default {
             this.$router.history.current.fullPath.split("?")[1]
           ) !== permalinktemp.split("?")[1]
         ) {
-          this.$router.replace({ path: "?" + permalinktemp.split("?")[1] });
+          this.$router.replace({
+            path: "?" + permalinktemp.split("?")[1],
+          });
         }
 
         this.$store.dispatch("Layers/setPermalink", permalinktemp);
@@ -177,12 +186,15 @@ export default {
   font-size: 1rem;
   letter-spacing: normal;
 }
+
 .share-icon {
   margin-bottom: 3px;
 }
+
 .share-text {
   margin-left: -8px;
 }
+
 #permaLink {
   pointer-events: auto;
   z-index: 4;

--- a/src/components/Map/MapCanvas.vue
+++ b/src/components/Map/MapCanvas.vue
@@ -353,8 +353,14 @@ export default {
       imageLayer.getSource().updateParams({
         STYLES: imageLayer.get("layerCurrentStyle"),
       });
-
-      if (
+      if (Object.hasOwn(layerData, "legendDisplayed")) {
+        if (layerData.legendDisplayed === "1") {
+          this.$store.dispatch(
+            "Layers/addActiveLegend",
+            imageLayer.get("layerName")
+          );
+        }
+      } else if (
         this.getActiveLegends.length === 0 &&
         imageLayer.get("layerStyles").length !== 0
       ) {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -56,7 +56,8 @@ export default {
       opacity,
       isSnapped,
       isVisible,
-      style
+      style,
+      legendDisplayed
     ) {
       var baseURL;
       const sourceContainingLayerName = this.findKeyInLocaleFiles(layerName);
@@ -80,6 +81,9 @@ export default {
       layer.visible = isVisible === "0" ? false : true;
       if (style !== "0") {
         layer.currentStyle = style;
+      }
+      if (legendDisplayed !== undefined) {
+        layer.legendDisplayed = legendDisplayed;
       }
       this.$root.$emit("permaLinkLayer", layer);
     },


### PR DESCRIPTION
The legend added to the map when loading from a permalink has always been the fastest layer to load. As such there was no consistency for the legend when loading from the permalink. Made a change so that it would be remembered for each layer and so that old permalinks would still work no problem.