### PR TITLE
Fixed error when language changed while GFI open

### DIFF
--- a/src/components/Map/GetFeatureInfo.vue
+++ b/src/components/Map/GetFeatureInfo.vue
@@ -95,11 +95,15 @@ export default {
     },
     changeGFILang() {
       this.items.forEach((item) => {
-        const value = item.children[0].name.split(":")[1];
-        item.children[0].name = `${this.$t("Value")}${this.$t(
-          "Colon"
-        )}${value}`;
-        item.children[1].name = this.$t("OtherProperties");
+        if (item.children[0].name.includes(":")) {
+          const value = item.children[0].name.split(":")[1];
+          item.children[0].name = `${this.$t("Value")}${this.$t(
+            "Colon"
+          )}${value}`;
+          item.children[1].name = this.$t("OtherProperties");
+        } else {
+          item.children[0].name = this.$t("OtherProperties");
+        }
       });
     },
     async onSingleClick(evt, overlay) {


### PR DESCRIPTION
Fixed a bug where I would try to translate the "value" GFI property of a layer that did not have a "value" property.