### PR TITLE
Added hide router property to hide different parts of the UI

### DIFF
--- a/src/components/GlobalConfigs/Share/PermaLink.vue
+++ b/src/components/GlobalConfigs/Share/PermaLink.vue
@@ -163,6 +163,10 @@ export default {
           permalinktemp += `&color=${rgb}`;
         }
 
+        if (Object.hasOwn(this.$router.history.current.query, "hide")) {
+          permalinktemp += `&hide=${this.$router.history.current.query.hide}`;
+        }
+
         if (
           decodeURIComponent(
             this.$router.history.current.fullPath.split("?")[1]

--- a/src/components/Map/CustomOLControls.vue
+++ b/src/components/Map/CustomOLControls.vue
@@ -16,6 +16,7 @@
       absolute
       @click="zoomIn"
       :disabled="isAnimating"
+      v-show="!getHidden.zoom"
     >
       <v-icon>mdi-plus</v-icon>
     </v-btn>
@@ -36,6 +37,7 @@
       absolute
       @click="zoomOut"
       :disabled="isAnimating"
+      v-show="!getHidden.zoom"
     >
       <v-icon>mdi-minus</v-icon>
     </v-btn>
@@ -61,7 +63,11 @@ export default {
     },
   },
   computed: {
-    ...mapGetters("Layers", ["getCollapsedControls", "getMapTimeSettings"]),
+    ...mapGetters("Layers", [
+      "getCollapsedControls",
+      "getHidden",
+      "getMapTimeSettings",
+    ]),
     ...mapState("Layers", ["isAnimating"]),
   },
 };

--- a/src/components/Map/GlobalConfigs.vue
+++ b/src/components/Map/GlobalConfigs.vue
@@ -2,18 +2,20 @@
   <v-container fluid id="global_configs">
     <v-row class="align-center ma-0 justify-space-between">
       <v-col cols="0" lg="4" class="pa-0"></v-col>
-      <v-col cols="12" lg="4" class="pa-0 pt-2"> <animet-logo /> </v-col>
+      <v-col cols="12" lg="4" class="pa-0 pt-2" v-show="!getHidden.title">
+        <animet-logo />
+      </v-col>
       <v-col
         cols="12"
         lg="4"
         class="d-flex pa-0 pt-2 justify-center align-center"
       >
         <v-spacer v-if="$vuetify.breakpoint.lgAndUp"></v-spacer>
-        <legend-selector class="mr-3" />
-        <map-customization class="mr-3" />
-        <page-theme class="mr-3" />
-        <language-select class="mr-3" />
-        <perma-link class="mr-3" />
+        <legend-selector class="mr-3" v-show="!getHidden.topMenus" />
+        <map-customization class="mr-3" v-show="!getHidden.topMenus" />
+        <page-theme class="mr-3" v-show="!getHidden.topMenus" />
+        <language-select class="mr-3" v-show="!getHidden.topMenus" />
+        <perma-link class="mr-3" v-show="!getHidden.topMenus" />
         <v-tooltip bottom>
           <template v-slot:activator="{ on, attrs }">
             <v-btn
@@ -25,6 +27,7 @@
               v-on="on"
               :href="$t('DocumentationURL')"
               target="_blank"
+              v-show="!getHidden.topMenus"
             >
               <v-icon> mdi-information-outline </v-icon>
             </v-btn>
@@ -44,6 +47,8 @@ import MapCustomization from "../GlobalConfigs/MapCustomization.vue";
 import PageTheme from "../GlobalConfigs/PageTheme.vue";
 import PermaLink from "../GlobalConfigs/Share/PermaLink.vue";
 
+import { mapGetters } from "vuex";
+
 export default {
   components: {
     AnimetLogo,
@@ -52,6 +57,9 @@ export default {
     MapCustomization,
     PageTheme,
     PermaLink,
+  },
+  computed: {
+    ...mapGetters("Layers", ["getHidden"]),
   },
 };
 </script>

--- a/src/components/Map/SidePanel.vue
+++ b/src/components/Map/SidePanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="side_panel">
+  <div id="side_panel" v-show="!getHidden.sidePanel">
     <v-menu
       eager
       v-model="toggleMenu"
@@ -171,7 +171,7 @@ export default {
     },
   },
   computed: {
-    ...mapGetters("Layers", ["getMapTimeSettings"]),
+    ...mapGetters("Layers", ["getHidden", "getMapTimeSettings"]),
     layersLength() {
       return this.$mapLayers.arr.length;
     },

--- a/src/components/Time/TimeControls.vue
+++ b/src/components/Time/TimeControls.vue
@@ -2,6 +2,7 @@
   <v-card
     id="time-controls"
     :class="getCollapsedControls ? 'time-controls-collapsed' : ''"
+    v-show="!getHidden.timeControls"
   >
     <div class="controller-padding" v-if="getMapTimeSettings.Step !== null">
       <div v-if="screenWidth >= 565">
@@ -410,6 +411,7 @@ export default {
     ...mapGetters("Layers", [
       "getCollapsedControls",
       "getDatetimeRangeSlider",
+      "getHidden",
       "getMapTimeSettings",
     ]),
     ...mapState("Layers", ["isAnimating", "playState"]),

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -16,6 +16,7 @@ const router = new Router({
         extent: route.query.extent,
         color: route.query.color,
         basemap: route.query.basemap,
+        hide: route.query.hide,
       }),
     },
   ],

--- a/src/store/modules/Layers.js
+++ b/src/store/modules/Layers.js
@@ -23,6 +23,13 @@ const state = {
   extent: null,
   framesPerSecond: 3,
   fullTimestepsList: [],
+  hidden: {
+    title: false,
+    topMenus: false,
+    timeControls: false,
+    sidePanel: false,
+    zoom: false,
+  },
   isAnimating: false,
   isAnimationReversed: false,
   isBasemapVisible: true,
@@ -116,6 +123,9 @@ const getters = {
   getGeoMetWmsSources: (state) => {
     return state.wmsSources;
   },
+  getHidden: (state) => {
+    return state.hidden;
+  },
   getMapTimeSettings: (state) => {
     return state.mapTimeSettings;
   },
@@ -204,6 +214,9 @@ const mutations = {
   },
   setFramesPerSecond: (state, fps) => {
     state.framesPerSecond = fps;
+  },
+  setHidden: (state, hiddenComponents) => {
+    state.hidden = hiddenComponents;
   },
   setIsAnimating: (state, newStatus) => {
     state.isAnimating = newStatus;
@@ -302,6 +315,9 @@ const actions = {
   },
   setExtent({ commit }, payload) {
     commit("setExtent", payload);
+  },
+  setHidden({ commit }, payload) {
+    commit("setHidden", payload);
   },
   setIsAnimating({ commit }, payload) {
     commit("setIsAnimating", payload);

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -16,7 +16,7 @@ import localeData from "../locales/importLocaleFiles";
 
 export default {
   name: "Home",
-  props: ["layers", "extent", "width", "height", "color"],
+  props: ["layers", "extent", "color", "basemap", "hide"],
   async mounted() {
     if (this.layers !== undefined) {
       const layersPassed = this.layers.split(",");
@@ -46,6 +46,28 @@ export default {
           ]);
           this.$root.$emit("permalinkColor", true);
         }
+      }
+    }
+    if (this.hide !== undefined) {
+      const componentsToHide = this.hide.split(",");
+      if (componentsToHide.includes("all")) {
+        const objectsToHide = {
+          title: true,
+          topMenus: true,
+          timeControls: true,
+          sidePanel: true,
+          zoom: true,
+        };
+        this.$store.dispatch("Layers/setHidden", objectsToHide);
+      } else {
+        const objectsToHide = {
+          title: componentsToHide.includes("title"),
+          topMenus: componentsToHide.includes("top"),
+          timeControls: componentsToHide.includes("time"),
+          sidePanel: componentsToHide.includes("side"),
+          zoom: componentsToHide.includes("zoom"),
+        };
+        this.$store.dispatch("Layers/setHidden", objectsToHide);
       }
     }
   },


### PR DESCRIPTION
Add `&hide=` with the appropriate parameters in the permalink to hide those components from the screen.
Used so AniMet can be put as a small iframe inside a website without having all the clutter surrounding it.
Parameters are:
- `title` to hide the title;
- `top` to hide the top icons;
- `time` to remove the time controls;
- `side` to remove the side panel;
- `zoom` to remove the zoom buttons;
- `all` to remove all of the above.