### PR TITLE
Removed hide since poor implementation and not used

### DIFF
--- a/src/components/GlobalConfigs/Share/PermaLink.vue
+++ b/src/components/GlobalConfigs/Share/PermaLink.vue
@@ -163,10 +163,6 @@ export default {
           permalinktemp += `&color=${rgb}`;
         }
 
-        if (Object.hasOwn(this.$router.history.current.query, "hide")) {
-          permalinktemp += `&hide=${this.$router.history.current.query.hide}`;
-        }
-
         if (
           decodeURIComponent(
             this.$router.history.current.fullPath.split("?")[1]

--- a/src/components/Map/CustomOLControls.vue
+++ b/src/components/Map/CustomOLControls.vue
@@ -16,7 +16,6 @@
       absolute
       @click="zoomIn"
       :disabled="isAnimating"
-      v-show="!getHidden.zoom"
     >
       <v-icon>mdi-plus</v-icon>
     </v-btn>
@@ -37,7 +36,6 @@
       absolute
       @click="zoomOut"
       :disabled="isAnimating"
-      v-show="!getHidden.zoom"
     >
       <v-icon>mdi-minus</v-icon>
     </v-btn>
@@ -63,11 +61,7 @@ export default {
     },
   },
   computed: {
-    ...mapGetters("Layers", [
-      "getCollapsedControls",
-      "getHidden",
-      "getMapTimeSettings",
-    ]),
+    ...mapGetters("Layers", ["getCollapsedControls", "getMapTimeSettings"]),
     ...mapState("Layers", ["isAnimating"]),
   },
 };

--- a/src/components/Map/GlobalConfigs.vue
+++ b/src/components/Map/GlobalConfigs.vue
@@ -2,7 +2,7 @@
   <v-container fluid id="global_configs">
     <v-row class="align-center ma-0 justify-space-between">
       <v-col cols="0" lg="4" class="pa-0"></v-col>
-      <v-col cols="12" lg="4" class="pa-0 pt-2" v-show="!getHidden.title">
+      <v-col cols="12" lg="4" class="pa-0 pt-2">
         <animet-logo />
       </v-col>
       <v-col
@@ -11,11 +11,11 @@
         class="d-flex pa-0 pt-2 justify-center align-center"
       >
         <v-spacer v-if="$vuetify.breakpoint.lgAndUp"></v-spacer>
-        <legend-selector class="mr-3" v-show="!getHidden.topMenus" />
-        <map-customization class="mr-3" v-show="!getHidden.topMenus" />
-        <page-theme class="mr-3" v-show="!getHidden.topMenus" />
-        <language-select class="mr-3" v-show="!getHidden.topMenus" />
-        <perma-link class="mr-3" v-show="!getHidden.topMenus" />
+        <legend-selector class="mr-3" />
+        <map-customization class="mr-3" />
+        <page-theme class="mr-3" />
+        <language-select class="mr-3" />
+        <perma-link class="mr-3" />
         <v-tooltip bottom>
           <template v-slot:activator="{ on, attrs }">
             <v-btn
@@ -27,7 +27,6 @@
               v-on="on"
               :href="$t('DocumentationURL')"
               target="_blank"
-              v-show="!getHidden.topMenus"
             >
               <v-icon> mdi-information-outline </v-icon>
             </v-btn>
@@ -47,8 +46,6 @@ import MapCustomization from "../GlobalConfigs/MapCustomization.vue";
 import PageTheme from "../GlobalConfigs/PageTheme.vue";
 import PermaLink from "../GlobalConfigs/Share/PermaLink.vue";
 
-import { mapGetters } from "vuex";
-
 export default {
   components: {
     AnimetLogo,
@@ -57,9 +54,6 @@ export default {
     MapCustomization,
     PageTheme,
     PermaLink,
-  },
-  computed: {
-    ...mapGetters("Layers", ["getHidden"]),
   },
 };
 </script>

--- a/src/components/Map/LegendControls.vue
+++ b/src/components/Map/LegendControls.vue
@@ -1,7 +1,6 @@
 <template>
   <div
     class="resizable draggable-container"
-    :class="{ 'hidden-top': getHidden.title && getHidden.topMenus }"
     ref="draggableContainer"
     @mousedown="dragMouseDown"
     @touchstart="dragMouseDown"
@@ -34,11 +33,7 @@ export default {
     };
   },
   computed: {
-    ...mapGetters("Layers", [
-      "getActiveLegends",
-      "getColorBorder",
-      "getHidden",
-    ]),
+    ...mapGetters("Layers", ["getActiveLegends", "getColorBorder"]),
     ...mapState("Layers", ["isAnimating"]),
     getStyle() {
       if (this.getColorBorder) {
@@ -127,10 +122,6 @@ export default {
 </script>
 
 <style scoped>
-.hidden-top {
-  top: 0 !important;
-  left: 0 !important;
-}
 .resizable {
   display: inline-block;
   resize: horizontal;

--- a/src/components/Map/MapCanvas.vue
+++ b/src/components/Map/MapCanvas.vue
@@ -27,7 +27,6 @@
             : 'animet-version-open'
           : ''
       "
-      v-show="!getHidden.info"
       >{{ `${$t("MSCAnimet")} ${version}` }}</span
     >
   </div>
@@ -438,7 +437,6 @@ export default {
     ...mapGetters("Layers", [
       "getActiveLegends",
       "getCollapsedControls",
-      "getHidden",
       "getHoldExtent",
       "getMapTimeSettings",
     ]),
@@ -475,21 +473,6 @@ export default {
         scaleLineElement.classList.add("scale-line-open");
         scaleLineElement.classList.remove("scale-line-collapsed");
       }
-    },
-    "getHidden.info": {
-      async handler(hideInfos) {
-        if (hideInfos) {
-          await this.waitForElements();
-          const scaleLineElement = document.querySelector(".ol-scale-line");
-          const attributionElement = document.querySelector(
-            ".ol-attribution.ol-uncollapsible"
-          );
-          const rotateElement = document.querySelector(".ol-rotate");
-          scaleLineElement.classList.add("hidden");
-          attributionElement.classList.add("hidden");
-          rotateElement.classList.add("hidden");
-        }
-      },
     },
     async timeStep(newStep, oldStep) {
       await this.waitForElements();
@@ -559,9 +542,6 @@ export default {
 }
 .ol-scale-line {
   bottom: 18px;
-}
-.hidden {
-  display: none;
 }
 @media (max-width: 1120px) {
   .scale-line-collapsed {

--- a/src/components/Map/SidePanel.vue
+++ b/src/components/Map/SidePanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="side_panel" v-if="!getHidden.sidePanel">
+  <div id="side_panel">
     <v-menu
       eager
       v-model="toggleMenu"
@@ -171,7 +171,7 @@ export default {
     },
   },
   computed: {
-    ...mapGetters("Layers", ["getHidden", "getMapTimeSettings"]),
+    ...mapGetters("Layers", ["getMapTimeSettings"]),
     layersLength() {
       return this.$mapLayers.arr.length;
     },

--- a/src/components/Time/TimeControls.vue
+++ b/src/components/Time/TimeControls.vue
@@ -2,7 +2,6 @@
   <v-card
     id="time-controls"
     :class="getCollapsedControls ? 'time-controls-collapsed' : ''"
-    v-show="!getHidden.timeControls"
   >
     <div class="controller-padding" v-if="getMapTimeSettings.Step !== null">
       <div v-if="screenWidth >= 565">
@@ -411,7 +410,6 @@ export default {
     ...mapGetters("Layers", [
       "getCollapsedControls",
       "getDatetimeRangeSlider",
-      "getHidden",
       "getMapTimeSettings",
     ]),
     ...mapState("Layers", ["isAnimating", "playState"]),

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -16,7 +16,6 @@ const router = new Router({
         extent: route.query.extent,
         color: route.query.color,
         basemap: route.query.basemap,
-        hide: route.query.hide,
       }),
     },
   ],

--- a/src/store/modules/Layers.js
+++ b/src/store/modules/Layers.js
@@ -23,14 +23,6 @@ const state = {
   extent: null,
   framesPerSecond: 3,
   fullTimestepsList: [],
-  hidden: {
-    info: false,
-    title: false,
-    topMenus: false,
-    timeControls: false,
-    sidePanel: false,
-    zoom: false,
-  },
   isAnimating: false,
   isAnimationReversed: false,
   isBasemapVisible: true,
@@ -124,9 +116,6 @@ const getters = {
   getGeoMetWmsSources: (state) => {
     return state.wmsSources;
   },
-  getHidden: (state) => {
-    return state.hidden;
-  },
   getMapTimeSettings: (state) => {
     return state.mapTimeSettings;
   },
@@ -215,9 +204,6 @@ const mutations = {
   },
   setFramesPerSecond: (state, fps) => {
     state.framesPerSecond = fps;
-  },
-  setHidden: (state, hiddenComponents) => {
-    state.hidden = hiddenComponents;
   },
   setIsAnimating: (state, newStatus) => {
     state.isAnimating = newStatus;
@@ -316,9 +302,6 @@ const actions = {
   },
   setExtent({ commit }, payload) {
     commit("setExtent", payload);
-  },
-  setHidden({ commit }, payload) {
-    commit("setHidden", payload);
   },
   setIsAnimating({ commit }, payload) {
     commit("setIsAnimating", payload);

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -16,7 +16,7 @@ import localeData from "../locales/importLocaleFiles";
 
 export default {
   name: "Home",
-  props: ["layers", "extent", "color", "basemap", "hide"],
+  props: ["layers", "extent", "color", "basemap"],
   async mounted() {
     if (this.layers !== undefined) {
       const layersPassed = this.layers.split(",");
@@ -46,32 +46,6 @@ export default {
           ]);
           this.$root.$emit("permalinkColor", true);
         }
-      }
-    }
-    if (this.hide !== undefined) {
-      const componentsToHide = this.hide.split(",");
-      if (componentsToHide.includes("all")) {
-        const objectsToHide = {
-          info: true,
-          title: true,
-          topMenus: true,
-          timeControls: true,
-          sidePanel: true,
-          zoom: true,
-        };
-        this.$store.dispatch("Layers/setHidden", objectsToHide);
-      } else {
-        const objectsToHide = {
-          info:
-            componentsToHide.includes("info") ||
-            componentsToHide.includes("time"),
-          title: componentsToHide.includes("title"),
-          topMenus: componentsToHide.includes("top"),
-          timeControls: componentsToHide.includes("time"),
-          sidePanel: componentsToHide.includes("side"),
-          zoom: componentsToHide.includes("zoom"),
-        };
-        this.$store.dispatch("Layers/setHidden", objectsToHide);
       }
     }
   },


### PR DESCRIPTION
Ability to hide was initially added to use as part of a thumbnail, but it would load quite slowly and the components were just hidden, but the code still had to wait for them to be rendered before hiding them, which made it even worse.
As such, hide parameter has been removed from the permalink and all the code associated with it.
(Did not want to revert merge since I also pushed bugfixes with it)