### PR TITLE
Fixed legends ordering and wrong menu size

### DIFF
--- a/src/components/GlobalConfigs/LegendSelector.vue
+++ b/src/components/GlobalConfigs/LegendSelector.vue
@@ -91,7 +91,8 @@ export default {
       return this.$mapLayers.arr
         .slice()
         .filter((l) => l.get("layerStyles").length !== 0)
-        .map((l) => l.get("layerName"));
+        .map((l) => l.get("layerName"))
+        .reverse();
     },
     toggleMenu: {
       get() {

--- a/src/components/Layers/StyleHandler.vue
+++ b/src/components/Layers/StyleHandler.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-menu bottom offset-y>
+  <v-menu eager bottom offset-y class="style-selector">
     <template v-slot:activator="{ on: menu, attrs }">
       <v-tooltip bottom>
         <template v-slot:activator="{ on: tooltip }">
@@ -11,7 +11,6 @@
             icon
             :disabled="isAnimating || item.get('layerStyles').length === 0"
             hide-details
-            class="style-selector"
           >
             <v-icon> mdi-palette </v-icon>
           </v-btn>


### PR DESCRIPTION
Fixed small bug where the legends' order was the opposite of the layer configuration.
Fixed a bug where the legends in the style selector would be too wide and put the menu outside the screen.