### PR TITLE
Support for permanent animation looping

### DIFF
--- a/src/components/Animation/CreateAnimation.vue
+++ b/src/components/Animation/CreateAnimation.vue
@@ -79,7 +79,7 @@ export default {
       }
     },
     cancelAnimationFromResize() {
-      if (this.isAnimating) {
+      if (this.isAnimating && this.playState !== "play") {
         this.$root.$emit("cancelAnimationResize");
         this.cancelAnimationCreation();
       }

--- a/src/components/GlobalConfigs/LanguageSelect.vue
+++ b/src/components/GlobalConfigs/LanguageSelect.vue
@@ -6,7 +6,7 @@
       height="34px"
       class="rounded-circle font-weight-bold"
       @click="changeLang"
-      :disabled="isAnimating"
+      :disabled="isAnimating && playState !== 'play'"
     >
       {{ this.getFlagLang }}
     </v-btn>
@@ -33,7 +33,7 @@ export default {
     },
   },
   computed: {
-    ...mapState("Layers", ["isAnimating"]),
+    ...mapState("Layers", ["isAnimating", "playState"]),
     getFlagLang() {
       if (this.$i18n.locale === "fr") {
         return "EN";

--- a/src/components/Map/CustomOLControls.vue
+++ b/src/components/Map/CustomOLControls.vue
@@ -15,7 +15,7 @@
       x-small
       absolute
       @click="zoomIn"
-      :disabled="isAnimating"
+      :disabled="isAnimating && playState !== 'play'"
     >
       <v-icon>mdi-plus</v-icon>
     </v-btn>
@@ -35,7 +35,7 @@
       x-small
       absolute
       @click="zoomOut"
-      :disabled="isAnimating"
+      :disabled="isAnimating && playState !== 'play'"
     >
       <v-icon>mdi-minus</v-icon>
     </v-btn>
@@ -62,7 +62,7 @@ export default {
   },
   computed: {
     ...mapGetters("Layers", ["getCollapsedControls", "getMapTimeSettings"]),
-    ...mapState("Layers", ["isAnimating"]),
+    ...mapState("Layers", ["isAnimating", "playState"]),
   },
 };
 </script>

--- a/src/components/Map/LegendControls.vue
+++ b/src/components/Map/LegendControls.vue
@@ -49,7 +49,7 @@ export default {
       "getColorBorder",
       "getLegendIndex",
     ]),
-    ...mapState("Layers", ["isAnimating"]),
+    ...mapState("Layers", ["isAnimating", "playState"]),
     getLegendHidden() {
       const getVisible = this.$mapLayers.arr
         .find((l) => l.get("layerName") === this.name)
@@ -88,7 +88,7 @@ export default {
         .LegendURL;
     },
     dragMouseDown: function (event) {
-      if (this.isAnimating) {
+      if (this.isAnimating && this.playState !== "play") {
         event.preventDefault();
         return;
       }

--- a/src/components/Time/AnimationControls/ControllerOptions.vue
+++ b/src/components/Time/AnimationControls/ControllerOptions.vue
@@ -23,6 +23,7 @@
         :key="action"
         hide-details
         class="px-3 pt-0 pb-2 mt-0"
+        :input-value="action === 'Loop' ? isLooping : false"
         @change="$emit('action-clicked', action)"
       >
         <template v-slot:label>
@@ -43,13 +44,20 @@
 import { mapState } from "vuex";
 
 export default {
+  mounted() {
+    this.$nextTick(() => {
+      if (this.isLooping) {
+        this.$emit("action-clicked", "Loop");
+      }
+    });
+  },
   data() {
     return {
       controllerOptions: ["Reverse", "Loop"],
     };
   },
   computed: {
-    ...mapState("Layers", ["isAnimating"]),
+    ...mapState("Layers", ["isAnimating", "isLooping"]),
   },
 };
 </script>

--- a/src/components/Time/AnimationControls/PlayPauseControls.vue
+++ b/src/components/Time/AnimationControls/PlayPauseControls.vue
@@ -78,6 +78,7 @@ export default {
         this.playbackReversed = !this.playbackReversed;
       } else if (action === "Loop") {
         this.loop = !this.loop;
+        this.$store.dispatch("Layers/setIsLooping", this.loop);
       }
     },
     playPause() {

--- a/src/components/Time/IntervalLocaleSelector.vue
+++ b/src/components/Time/IntervalLocaleSelector.vue
@@ -19,7 +19,7 @@
       </v-select>
       <v-switch
         class="locale-switch"
-        :disabled="isAnimating"
+        :disabled="isAnimating && playState !== 'play'"
         v-model="timeFormat"
         hide-details
         :label="$t('MP4CreateTimeFormat')"
@@ -45,7 +45,7 @@
       </v-select>
       <v-switch
         class="locale-switch"
-        :disabled="isAnimating"
+        :disabled="isAnimating && playState !== 'play'"
         v-model="timeFormat"
         hide-details
         :label="$t('MP4CreateTimeFormat')"
@@ -114,7 +114,7 @@ export default {
       "getTimeFormat",
       "getUniqueTimestepsList",
     ]),
-    ...mapState("Layers", ["isAnimating"]),
+    ...mapState("Layers", ["isAnimating", "playState"]),
     timeFormat: {
       get() {
         return this.getTimeFormat;

--- a/src/components/Time/TimeControls.vue
+++ b/src/components/Time/TimeControls.vue
@@ -202,8 +202,10 @@ export default {
       );
       if (this.cancelExpired) {
         if (playStateBuffer === "play") {
-          this.$store.commit("Layers/setPlayState", "pause");
-          this.$store.commit("Layers/setIsAnimating", false);
+          if (!this.isLooping) {
+            this.$store.commit("Layers/setPlayState", "pause");
+            this.$store.commit("Layers/setIsAnimating", false);
+          }
           this.$root.$emit("fixTimeExtent");
         } else if (!this.isAnimating) {
           this.$root.$emit("fixTimeExtent");
@@ -412,7 +414,7 @@ export default {
       "getDatetimeRangeSlider",
       "getMapTimeSettings",
     ]),
-    ...mapState("Layers", ["isAnimating", "playState"]),
+    ...mapState("Layers", ["isAnimating", "isLooping", "playState"]),
     layerList() {
       return this.$mapLayers.arr.length;
     },

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -41,6 +41,7 @@
   "LayerTree": "Add",
   "Loading": "Loading...",
   "Loop": "Loop",
+  "LoopRetry": "Service unavailable. Retrying in 45 seconds.",
   "MadeWithAniMet": "Made with MSC AniMet",
   "Major_cities": "Canadian cities",
   "MapCustomizations": "Customize map",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -41,6 +41,7 @@
   "LayerTree": "Ajouter",
   "Loading": "Chargement...",
   "Loop": "Lecture en boucle",
+  "LoopRetry": "Service non disponible. Nouvelle tentative dans 45 secondes.",
   "MadeWithAniMet": "Créé avec AniMet du SMC",
   "Major_cities": "Villes canadiennes",
   "MapCustomizations": "Personnaliser la carte",

--- a/src/store/modules/Layers.js
+++ b/src/store/modules/Layers.js
@@ -43,6 +43,7 @@ const state = {
   isAnimating: false,
   isAnimationReversed: false,
   isBasemapVisible: true,
+  isLooping: false,
   lang: "en",
   layerTreeItemsEn: Object.keys(wmsSources).map((key) => {
     const treeName = "tree_en_" + key.toLowerCase();
@@ -261,6 +262,9 @@ const mutations = {
   setIsBasemapVisible: (state, newStatus) => {
     state.isBasemapVisible = newStatus;
   },
+  setIsLooping: (state, looping) => {
+    state.isLooping = looping;
+  },
   setLang: (state, lang) => {
     state.lang = lang;
   },
@@ -370,6 +374,9 @@ const actions = {
   },
   setIsBasemapVisible({ commit }, payload) {
     commit("setIsBasemapVisible", payload);
+  },
+  setIsLooping({ commit }, payload) {
+    commit("setIsLooping", payload);
   },
   setLang({ commit }, payload) {
     commit("setLang", payload);


### PR DESCRIPTION
- If a timestep is missing or needs refresh, continue animating if it's looping;
- If I receive a 500 error or any error of the sort, pause and wait 45sec and try again every 45sec if the loop is still active;
- If the user pauses during the 45sec wait, trigger all the pending errors;
- If an error like 500 occurs, clears out and no new errors show up, continue execution as normal, otherwise handle new error;
- Fixed small bug where the animation resize error would show up even though we weren't in animation creation mode;
- Allowed a bit more options when only animating through Play vs creating an animation.