### PR TITLE
Auto refresh finally working

### DIFF
--- a/src/components/Animation/AnimationConfiguration.vue
+++ b/src/components/Animation/AnimationConfiguration.vue
@@ -43,6 +43,7 @@
       <v-switch
         hide-details
         class="colored-border-switch"
+        :disabled="isAnimating"
         :label="$t('ColorBorder')"
         v-model="colorBorder"
       ></v-switch>

--- a/src/components/Layers/ModelRunHandler.vue
+++ b/src/components/Layers/ModelRunHandler.vue
@@ -40,20 +40,39 @@ export default {
           newDateArray.push(new Date(date.getTime() + timeDiff))
         );
 
-      this.item.getSource().updateParams({
-        DIM_REFERENCE_TIME: this.getProperDateString(
-          newModelRun,
-          this.item.get("layerDateFormat")
-        ),
-      });
+      if (
+        newModelRun ===
+        this.item.get("layerModelRuns")[
+          this.item.get("layerModelRuns").length - 1
+        ]
+      ) {
+        this.item.getSource().updateParams({
+          DIM_REFERENCE_TIME: undefined,
+        });
+      } else {
+        this.item.getSource().updateParams({
+          DIM_REFERENCE_TIME: this.getProperDateString(
+            newModelRun,
+            this.item.get("layerDateFormat")
+          ),
+        });
+      }
+      const layerActiveConfig = this.item.get("layerActiveConfig");
+      const configs = this.item.get("layerConfigs");
+      configs[layerActiveConfig].layerDateArray = newDateArray;
+      configs[layerActiveConfig].layerStartTime = newDateArray[0];
+      configs[layerActiveConfig].layerEndTime =
+        newDateArray[newDateArray.length - 1];
+
       this.item.setProperties({
+        layerConfigs: configs,
         layerDateArray: newDateArray,
         layerDefaultTime: new Date(
           this.item.get("layerDefaultTime").getTime() + timeDiff
         ),
         layerCurrentMR: newModelRun,
-        layerStartTime: newDateArray[0],
-        layerEndTime: newDateArray[newDateArray.length - 1],
+        layerStartTime: configs[layerActiveConfig].layerStartTime,
+        layerEndTime: configs[layerActiveConfig].layerEndTime,
       });
       this.$root.$emit("modelRunChanged");
       this.$root.$emit("calcFooterPreview");

--- a/src/components/Map/MapCanvas.vue
+++ b/src/components/Map/MapCanvas.vue
@@ -30,6 +30,7 @@
       "
       >{{ `${$t("MSCAnimet")} ${version}` }}</span
     >
+    <auto-refresh />
   </div>
 </template>
 
@@ -53,6 +54,7 @@ import { mapGetters, mapState } from "vuex";
 
 import AnimationCanvas from "../Animation/AnimationCanvas.vue";
 import AnimationRectangle from "../Animation/AnimationRectangle.vue";
+import AutoRefresh from "../Time/AutoRefresh.vue";
 import CustomOLControls from "./CustomOLControls.vue";
 import GetFeatureInfo from "./GetFeatureInfo.vue";
 import GlobalConfigs from "./GlobalConfigs.vue";
@@ -65,6 +67,7 @@ export default {
   components: {
     AnimationCanvas,
     AnimationRectangle,
+    AutoRefresh,
     CustomOLControls,
     GetFeatureInfo,
     GlobalConfigs,
@@ -274,6 +277,7 @@ export default {
           this.selectedLegendLayerName
         );
         this.selectedLegendLayerName = null;
+        this.$root.$emit("updatePermalink");
       }
     },
     selectImage(layerName) {

--- a/src/components/Time/AutoRefresh.vue
+++ b/src/components/Time/AutoRefresh.vue
@@ -1,0 +1,100 @@
+<template></template>
+
+<script>
+import axios from "axios";
+import SaxonJS from "saxon-js";
+export default {
+  data() {
+    return {
+      interval: setInterval(this.fetchLayerData, 90000),
+      layers: [],
+      xsltTime: `parse-xml($xml)//Layer[not(.//Layer) and Name = 'REPLACE_WITH_LAYERNAME']!map
+                      {
+                          'Dimension' : map
+                          {
+                              'Dimension_time' : string(Dimension[@name = 'time']),
+                              'Dimension_time_default' : string(Dimension[@name = 'time']/@default),
+                              'Dimension_ref_time' : string(Dimension[@name = 'reference_time'])
+                          }
+                      }`,
+    };
+  },
+  mounted() {
+    this.$root.$on("timeLayerAdded", (layerName) => {
+      this.layers.push(layerName);
+    });
+    this.$root.$on("timeLayerRemoved", (layer) => {
+      this.layers = this.layers.filter((l) => l !== layer.get("layerName"));
+    });
+  },
+  beforeDestroy() {
+    this.stopPolling();
+  },
+  methods: {
+    checkRefresh(layersInfo) {
+      let errorList = [];
+      layersInfo.forEach((layerInfo) => {
+        if (
+          layerInfo["layer"].get("layerDimensionTime") !==
+            layerInfo["layerData"].Dimension.Dimension_time ||
+          layerInfo["layer"].get("layerDimensionRefTime") !==
+            layerInfo["layerData"].Dimension.Dimension_ref_time
+        ) {
+          errorList.push(layerInfo["layer"]);
+        }
+      });
+      if (errorList.length !== 0) {
+        this.$root.$emit("refreshExpired", errorList);
+      }
+    },
+    stopPolling() {
+      clearInterval(this.interval);
+    },
+    async fetchLayerData() {
+      let layersInfo = [];
+      let layerData;
+      await Promise.all(
+        this.layers.map(async (layerName) => {
+          try {
+            const layer = this.$mapLayers.arr.find(
+              (l) => l.get("layerName") === layerName
+            );
+            const api = axios.create({
+              baseURL: layer.get("source")["url_"],
+              params: {
+                SERVICE: "WMS",
+                VERSION: "1.3.0",
+                REQUEST: "GetCapabilities",
+                LAYERS: layerName,
+                t: new Date().getTime(),
+              },
+            });
+            await api.get().then((response) => {
+              layerData = SaxonJS.XPath.evaluate(
+                this.xsltTime.replace("REPLACE_WITH_LAYERNAME", layerName),
+                null,
+                {
+                  xpathDefaultNamespace: "http://www.opengis.net/wms",
+                  namespaceContext: {
+                    xlink: "http://www.w3.org/1999/xlink",
+                  },
+                  params: {
+                    xml: response.data,
+                  },
+                }
+              );
+            });
+            layersInfo.push({
+              layer: layer,
+              layerData: layerData,
+            });
+          } catch (error) {
+            // pass, it'll be handled in the error manager
+          }
+        })
+      );
+      this.checkRefresh(layersInfo);
+    },
+  },
+};
+</script>

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -45,7 +45,7 @@
   "MadeWithAniMet": "Made with MSC AniMet",
   "Major_cities": "Canadian cities",
   "MapCustomizations": "Customize map",
-  "MissingTimesteps": "Some requested timesteps could not be retrieved. The temporal values have been updated.",
+  "MissingTimesteps": "Some timesteps have expired. The temporal values have been updated.",
   "ModelRun": "Model run",
   "MP4CreateButtonLabel": "Create animation",
   "MP4CreateCancelAnimationCreation": "Cancel",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -45,7 +45,7 @@
   "MadeWithAniMet": "Créé avec AniMet du SMC",
   "Major_cities": "Villes canadiennes",
   "MapCustomizations": "Personnaliser la carte",
-  "MissingTimesteps": "Des pas de temps pour certaines couches sélectionnées ne sont pas disponibles. Les informations temporelles ont été mises à jour.",
+  "MissingTimesteps": "Certains pas de temps ont expiré. Les informations temporelles ont été mises à jour.",
   "ModelRun": "Passe du modèle",
   "MP4CreateButtonLabel": "Créer l'animation",
   "MP4CreateCancelAnimationCreation": "Annuler",


### PR DESCRIPTION
- Model run handling fixed:
  - If selected model run is the last one, update as new ones come in;
  - If another model run is manually selected, keep it for as long as possible;
  - Once a model run is no longer available, reset back to latest and start updating with new MRs again.
- Small improvements to `AnimationCanvas` layers' loading/loaded tracker;
- Disabled color border switch during animation;
- `AutoRefresh` file added. Keeps track of time-enabled layers and checks every 1min30sec to see if any of them have had updates to their getCapas;
- Permalink is now updated when a legend is removed through the `del` keyboard key;
- `AutoRefresh` uses `ErrorManager`'s `RefreshExpired` since it's the same thing;
- `blockRefresh` flag has been added to make sure errors and refreshes don't fight one another and error always takes priority;
- `cancelCriticalError` flag added so the loop simply stops where it is if there's an error like 500 on a single layer (otherwise it would continue going as long as at least one layer did not receive a 500);
- Removed `RefreshExpired`'s case where the getCapa would be wrong since that was mostly a fr vs en getCapa problem and the check used to see if it was correct or not now actually happens because of the looping logic (an error 500 followed by no error and getCapa is the same for example);
- `setDateTime` when a time layer is added otherwise it can cause problems with refreshes now;
- Added a delay of 100ms if no layers changed over a timestep otherwise the playHead would teleport, also manually trigger the render events during animation creation because in that case it would stop the animation dead in its track;
- Changed Extent rebuilding logic:
  - If the first thumb was on the first timestep available, the first thumb should stay there regardless of the changes;
  - If the last thumb was on the last timestep available, the last thumb it should stay there regardless of the changes;
  - If none of them were on the first/last, assume the exact dates are important and try to keep them if possible;
  - If a layer is snapped, ignore everything and re-snap to its new extent;
  - In case 1 and 2 where both are not true at the same time, assume the other date is not important and only the length of time is important.
- Changed expired timesteps message since it no longer only happens for an error, but also on the refresh itself.