### PR TITLE
Remove intersect message on legend hidden

### DIFF
--- a/src/components/Map/LegendControls.vue
+++ b/src/components/Map/LegendControls.vue
@@ -174,6 +174,14 @@ export default {
       this.checkIntersect();
     },
     checkIntersect() {
+      let layer = this.$mapLayers.arr.find(
+        (l) => l.get("layerName") === this.name
+      );
+      if (!layer.get("visible")) {
+        this.$store.dispatch("Layers/setIntersect", [this.name, false]);
+        return;
+      }
+
       const previewDims = document
         .getElementById("animation-rect")
         .getBoundingClientRect();


### PR DESCRIPTION
When a layer is put invisible, legend is put to `Display: none`, but not removed, so just need to make sure to remove the intersect in that case.