### PR TITLE
Refresh on non-time enabled, date size increase and 4-displays

### DIFF
--- a/src/components/Map/CustomOLControls.vue
+++ b/src/components/Map/CustomOLControls.vue
@@ -87,13 +87,13 @@ export default {
     bottom: 170px;
   }
   .zoom-plus-collapsed {
-    bottom: 79px;
+    bottom: 103px;
   }
   .zoom-minus-open {
     bottom: 138px;
   }
   .zoom-minus-collapsed {
-    bottom: 47px;
+    bottom: 71px;
   }
 }
 @media (max-width: 565px) {
@@ -101,13 +101,13 @@ export default {
     bottom: 224px;
   }
   .zoom-plus-collapsed {
-    bottom: 79px;
+    bottom: 103px;
   }
   .zoom-minus-open {
     bottom: 192px;
   }
   .zoom-minus-collapsed {
-    bottom: 47px;
+    bottom: 71px;
   }
 }
 </style>

--- a/src/components/Map/MapCanvas.vue
+++ b/src/components/Map/MapCanvas.vue
@@ -602,19 +602,19 @@ export default {
 }
 @media (max-width: 1120px) {
   .scale-line-collapsed {
-    bottom: 41px;
+    bottom: 65px;
   }
   .scale-line-open {
     bottom: 132px;
   }
   .rotate-collapsed {
-    bottom: 68px;
+    bottom: 92px;
   }
   .rotate-open {
     bottom: 159px;
   }
   .attribution-collapsed {
-    bottom: 22px !important;
+    bottom: 46px !important;
   }
   .attribution-open {
     bottom: 114px !important;
@@ -622,19 +622,19 @@ export default {
 }
 @media (max-width: 565px) {
   .scale-line-collapsed {
-    bottom: 41px;
+    bottom: 65px;
   }
   .scale-line-open {
     bottom: 186px;
   }
   .rotate-collapsed {
-    bottom: 68px;
+    bottom: 92px;
   }
   .rotate-open {
     bottom: 213px;
   }
   .attribution-collapsed {
-    bottom: 22px !important;
+    bottom: 46px !important;
   }
   .attribution-open {
     bottom: 168px !important;
@@ -666,7 +666,7 @@ export default {
 }
 @media (max-width: 1120px) {
   .animet-version-collapsed {
-    bottom: 25px !important;
+    bottom: 49px !important;
   }
   .animet-version-open {
     bottom: 116px !important;
@@ -674,7 +674,7 @@ export default {
 }
 @media (max-width: 565px) {
   .animet-version-collapsed {
-    bottom: 25px !important;
+    bottom: 49px !important;
   }
   .animet-version-open {
     bottom: 170px !important;

--- a/src/components/Time/TimeControls.vue
+++ b/src/components/Time/TimeControls.vue
@@ -22,19 +22,14 @@
           "
         >
           <v-icon v-if="!getCollapsedControls" large> mdi-chevron-down </v-icon>
-          <span
-            v-else
-            class="text-wrap"
-            :class="getCollapsedControls ? '' : 'hide-controls'"
-          >
-            {{
-              localeDateFormat(
-                getMapTimeSettings.Extent[getMapTimeSettings.DateIndex],
-                getMapTimeSettings.Step,
-                "DATETIME_MED"
-              )
-            }}
-          </span>
+          <div v-else>
+            <span class="collapsed-date">{{
+              getCollapsedDateFormat()[0]
+            }}</span>
+            <span class="collapsed-time">{{
+              getCollapsedDateFormat()[1]
+            }}</span>
+          </div>
         </v-btn>
       </div>
       <v-col class="mr-1 pt-2 pb-2 px-0" v-else>
@@ -55,19 +50,14 @@
           "
         >
           <v-icon v-if="!getCollapsedControls" large> mdi-chevron-down </v-icon>
-          <span
-            v-else
-            class="text-wrap"
-            :class="getCollapsedControls ? '' : 'hide-controls'"
-          >
-            {{
-              localeDateFormat(
-                getMapTimeSettings.Extent[getMapTimeSettings.DateIndex],
-                getMapTimeSettings.Step,
-                "DATETIME_FULL"
-              )
-            }}
-          </span>
+          <div v-else>
+            <span class="collapsed-date">{{
+              getCollapsedDateFormat()[0]
+            }}</span>
+            <span class="collapsed-time">{{
+              getCollapsedDateFormat()[1]
+            }}</span>
+          </div>
         </v-btn>
       </v-col>
     </div>
@@ -117,6 +107,11 @@ export default {
   methods: {
     delay(time) {
       return new Promise((resolve) => setTimeout(resolve, time));
+    },
+    getCollapsedDateFormat() {
+      return this.localeDateFormatAnimation(
+        this.getMapTimeSettings.Extent[this.getMapTimeSettings.DateIndex]
+      );
     },
     handleCancelExpired() {
       this.cancelExpired = true;
@@ -469,7 +464,19 @@ export default {
   margin-top: 6px;
   transform: translateY(-13px);
   width: 100%;
-  height: 26px !important;
+  height: 50px !important;
+}
+.collapsed-date {
+  display: block;
+  font-size: 16px;
+  text-transform: none !important;
+  white-space: nowrap !important;
+}
+.collapsed-time {
+  display: block;
+  font-size: 24px;
+  text-transform: none !important;
+  white-space: nowrap !important;
 }
 .controller-padding {
   margin-bottom: -16px;
@@ -494,13 +501,6 @@ export default {
   padding-top: 2px;
   padding-bottom: 0;
 }
-.text-wrap {
-  font-size: 16px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  text-transform: none !important;
-  white-space: nowrap !important;
-}
 #collapse-button::v-deep .v-btn__content {
   height: 20px;
 }
@@ -519,10 +519,10 @@ export default {
     pointer-events: auto;
     border-radius: 4px 4px 0 0;
     box-shadow: none;
-    margin-left: calc(27.5%);
+    margin-left: calc(35%);
     transform: translateY(10px);
-    width: 45%;
-    height: 26px !important;
+    width: 30%;
+    height: 50px !important;
   }
   .time-controls-collapsed {
     background-color: transparent;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -21,6 +21,11 @@ const router = new Router({
       }),
     },
     {
+      path: "/4-displays",
+      name: "FourDisplays",
+      component: require("@/views/FourDisplays").default,
+    },
+    {
       path: "*",
       name: "NotFound",
       component: require("@/views/NotFound").default,

--- a/src/views/FourDisplays.vue
+++ b/src/views/FourDisplays.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="page">
+    <iframe
+      v-for="n in 4"
+      :key="n"
+      src="https://eccc-msc.github.io/msc-animet/"
+      class="quadrant"
+    ></iframe>
+  </div>
+</template>
+
+<style scoped>
+.page {
+  height: 100%;
+  padding: 0;
+  margin: 0;
+}
+.quadrant {
+  width: 50%;
+  height: 50%;
+  float: left;
+}
+</style>


### PR DESCRIPTION
- Added a manual refresh on all non time-enabled layers every 9min;
- Changed the date in collapsed controls to be on 2 lines and the time is a bit bigger;
- Added a simple FourDisplays view that just contains 4 animets for big TV displays (semi-official feature).