### PR TITLE
Added 404.html so github.io uses vue router

### DIFF
--- a/deploy/gh-pages/deploy.sh
+++ b/deploy/gh-pages/deploy.sh
@@ -23,6 +23,7 @@ echo "Use .env for gh-pages"
 cp ./deploy/gh-pages/.env ./.env
 echo "Building and bundling application files..."
 npm run build
+cp ./dist/index.html ./dist/404.html
 git --work-tree dist add --all
 git --work-tree dist commit -m 'gh-pages deploy'
 echo "Pushing to gh-pages..."

--- a/src/views/FourDisplays.vue
+++ b/src/views/FourDisplays.vue
@@ -1,13 +1,20 @@
 <template>
   <div class="page">
-    <iframe
-      v-for="n in 4"
-      :key="n"
-      src="https://eccc-msc.github.io/msc-animet/"
-      class="quadrant"
-    ></iframe>
+    <iframe v-for="n in 4" :key="n" :src="iframeSrc" class="quadrant"></iframe>
   </div>
 </template>
+
+<script>
+export default {
+  computed: {
+    iframeSrc() {
+      return `${window.location.origin}/${
+        window.location.pathname.split("/")[1]
+      }`;
+    },
+  },
+};
+</script>
 
 <style scoped>
 .page {


### PR DESCRIPTION
When you’d be going on a wrong route, the page is gonna go “404 not found”, so by putting the entire index.html as 404.html, instead of throwing 404 it’ll go “ah ok I need to use your router for this 404” and it’ll go to my 404 or my other route accordingly.