### PR TITLE
4-Displays page will not remember each panel's permalink

### DIFF
--- a/src/views/FourDisplays.vue
+++ b/src/views/FourDisplays.vue
@@ -1,16 +1,49 @@
 <template>
   <div class="page">
-    <iframe v-for="n in 4" :key="n" :src="iframeSrc" class="quadrant"></iframe>
+    <iframe
+      v-for="(n, index) in 4"
+      :key="n"
+      :src="iframeSrc(index)"
+      class="quadrant"
+      :ref="`iframe-${index}`"
+      @load="iframeLoaded(index)"
+    ></iframe>
   </div>
 </template>
 
 <script>
 export default {
-  computed: {
-    iframeSrc() {
-      return `${window.location.origin}/${
+  mounted() {
+    if (localStorage.getItem("displays-url") !== null) {
+      const permalinks = JSON.parse(localStorage.getItem("displays-url"));
+      this.permalinkInfos = permalinks;
+    }
+  },
+  data() {
+    return {
+      permalinkInfos: ["", "", "", ""],
+    };
+  },
+  methods: {
+    iframeLoaded(index) {
+      // Update each permalink URL to the one currently displayed before leaving the page
+      const iframe = this.$refs[`iframe-${index}`][0];
+      iframe.contentWindow.onbeforeunload = () => {
+        this.permalinkInfos[index] =
+          iframe.contentWindow.location.href.split("?")[1];
+        if (index === 3) {
+          localStorage.setItem(
+            "displays-url",
+            JSON.stringify(this.permalinkInfos)
+          );
+        }
+      };
+    },
+    iframeSrc(index) {
+      const baseUrl = `${window.location.origin}/${
         window.location.pathname.split("/")[1]
       }`;
+      return `${baseUrl}?${this.permalinkInfos[index]}`;
     },
   },
 };


### PR DESCRIPTION
On page refresh or page close, store the permalink for each iframe inside localStorage and load localStorage urls if they exist.