### PR TITLE
Changed looping logic and added fix for upgrading ol version

### DIFF
--- a/src/components/Animation/AnimationCanvas.vue
+++ b/src/components/Animation/AnimationCanvas.vue
@@ -68,7 +68,7 @@ export default {
     addOverlays() {
       for (const [key, values] of Object.entries(this.getPossibleOverlays)) {
         if (values.isShown) {
-          let special_layer = new OLImage({
+          const special_layer = new OLImage({
             source: new ImageWMS({
               format: "image/png",
               url: values.url,

--- a/src/components/Time/ErrorManager.vue
+++ b/src/components/Time/ErrorManager.vue
@@ -195,12 +195,15 @@ export default {
       }
       this.$root.$emit("loadingStop");
       this.blockRefresh = false;
+      if (this.playState === "play") {
+        this.$root.$emit("playAnimation");
+      }
     },
     async errorDispatcher(layer, e) {
       this.blockRefresh = true;
       try {
         this.errorLayersList.push(layer.get("layerName"));
-        const response = await axios.get(e.image.src_);
+        const response = await axios.get(e.image.image_.currentSrc);
         const xmlDoc = new DOMParser().parseFromString(
           response.data,
           "text/xml"

--- a/src/store/modules/Layers.js
+++ b/src/store/modules/Layers.js
@@ -43,7 +43,7 @@ const state = {
   isAnimating: false,
   isAnimationReversed: false,
   isBasemapVisible: true,
-  isLooping: false,
+  isLooping: true,
   lang: "en",
   layerTreeItemsEn: Object.keys(wmsSources).map((key) => {
     const treeName = "tree_en_" + key.toLowerCase();


### PR DESCRIPTION
- Play logic has been moved to try and remove cases where there are multiple events triggered (for example paning and zooming while animation is looping);
- Changed how to access source URL in error handler to be able to upgrade openlayers version;
- Changed some `let` to `const` and tried to remove instances where useless object duplications where made;
- Looping is now true by default.