### PR TITLE
Fixed warning message not appearing on OOB

### DIFF
--- a/src/components/Map/LegendControls.vue
+++ b/src/components/Map/LegendControls.vue
@@ -177,7 +177,7 @@ export default {
       let layer = this.$mapLayers.arr.find(
         (l) => l.get("layerName") === this.name
       );
-      if (!layer.get("visible")) {
+      if (!layer.get("layerVisibilityOn")) {
         this.$store.dispatch("Layers/setIntersect", [this.name, false]);
         return;
       }


### PR DESCRIPTION
Fixed a bug where the warning message would not appear on intersection between legend and animation rectangle when the layer was out of bounds (red eye icon).