### PR TITLE
Fix attempt for network errors causing freezes and add/remove layers during animation

### DIFF
--- a/src/components/Animation/AnimationCanvas.vue
+++ b/src/components/Animation/AnimationCanvas.vue
@@ -285,12 +285,6 @@ export default {
           visibleTLayers[i].setVisible(false);
         }
       }
-      await new Promise((resolve) =>
-        this.$animationCanvas.mapObj.once("rendercomplete", resolve)
-      );
-      if (this.cancelExpired) {
-        this.$root.$emit("fixTimeExtent");
-      }
     },
     removeLayersListeners() {
       this.$mapCanvas.mapObj.getLayers().forEach((layer) => {

--- a/src/components/Layers/LayerTree.vue
+++ b/src/components/Layers/LayerTree.vue
@@ -61,7 +61,7 @@
                   v-if="!item.children"
                   icon
                   :disabled="
-                    isAnimating ||
+                    (isAnimating && playState !== 'play') ||
                     !getAvailableCRS[index].includes(getCurrentCRS)
                   "
                   @click="requestLayerData(item)"
@@ -195,6 +195,9 @@ export default {
   },
   methods: {
     async requestLayerData(layer) {
+      if (this.playState === "play") {
+        this.$root.$emit("stopAnimation");
+      }
       if (layer.isLeaf && !this.addedLayers.includes(layer.Name)) {
         let source = Object.hasOwn(layer, "wmsSource")
           ? layer.wmsSource
@@ -289,7 +292,7 @@ export default {
     },
   },
   computed: {
-    ...mapState("Layers", ["isAnimating"]),
+    ...mapState("Layers", ["isAnimating", "playState"]),
     ...mapGetters("Layers", [
       "getCurrentCRS",
       "getCurrentWmsSource",

--- a/src/components/Map/MapCanvas.vue
+++ b/src/components/Map/MapCanvas.vue
@@ -191,7 +191,6 @@ export default {
       const rotation = view.getRotation();
       this.$store.dispatch("Layers/setExtent", [extent, rotation]);
       this.$root.$emit("updatePermalink");
-      this.resizeRefreshExpired();
     });
 
     this.$mapCanvas.mapObj.on("singleclick", (evt) => {
@@ -215,12 +214,6 @@ export default {
     window.removeEventListener("keydown", this.removeLegend);
   },
   methods: {
-    async resizeRefreshExpired() {
-      await new Promise((resolve) =>
-        this.$mapCanvas.mapObj.once("rendercomplete", resolve)
-      );
-      this.$root.$emit("checkLoadingErrors");
-    },
     async goToExtentHandler(locExtent) {
       let rotation = 0;
       if (locExtent.length === 5) {

--- a/src/components/Time/AnimationControls/PlayPauseControls.vue
+++ b/src/components/Time/AnimationControls/PlayPauseControls.vue
@@ -34,16 +34,15 @@ import ControllerOptions from "./ControllerOptions.vue";
 
 export default {
   mounted() {
-    this.$root.$on("cancelExpired", () => {
-      this.cancelExpired = true;
-    });
     this.$root.$on("cancelCriticalError", (isError) => {
       this.cancelCriticalError = isError;
     });
     this.$root.$on("playAnimation", this.play);
+    this.$root.$on("stopAnimation", this.playPause);
   },
   beforeDestroy() {
     this.$root.$off("playAnimation", this.play);
+    this.$root.$off("stopAnimation", this.playPause);
   },
   components: {
     ControllerOptions,
@@ -51,7 +50,6 @@ export default {
   data() {
     return {
       cancelCriticalError: false,
-      cancelExpired: false,
       locked: false,
       loop: false,
       playbackReversed: false,
@@ -100,11 +98,11 @@ export default {
       return fn().then(onPromiseDone, onPromiseDone);
     },
     playPause() {
-      this.$root.$emit("changeTab");
       if (!this.locked) {
         this.locked = true;
         setTimeout(this.unlock, 1000);
         if (this.playState === "pause") {
+          this.$root.$emit("changeTab");
           if (!this.playbackReversed) {
             if (
               this.getMapTimeSettings.DateIndex !==
@@ -190,13 +188,7 @@ export default {
               this.$mapCanvas.mapObj.once("rendercomplete", resolve)
             )
         );
-        if (this.cancelExpired) {
-          if (this.playState === "play" || !this.isAnimating) {
-            this.playLocked = false;
-            this.$root.$emit("fixTimeExtent");
-            this.cancelExpired = false;
-          }
-        } else if (!this.cancelCriticalError && this.playState === "play") {
+        if (!this.cancelCriticalError && this.playState === "play") {
           if (r < 1000) {
             await this.delay(1000 - r);
           }


### PR DESCRIPTION
- Changed how the play loop worked slightly to try and make it so the `fixTimeExtent` method gets called whenever there's an issue, which should fix Freezes and timesteps erroring out and not being removed from the extent;
- Added possibility to remove or add layers during a `Play` event. It will stop the animation and do the desired action;
- Pressing the `Pause` button will no longer change tabs to layer configs, only pressing `Play` does now.