### PR TITLE
Fixed legends disappearing when changing tabs during animation creation

### DIFF
--- a/src/components/Animation/AnimationRectangle.vue
+++ b/src/components/Animation/AnimationRectangle.vue
@@ -179,7 +179,8 @@ export default {
           mapWidth
         );
         if (
-          document.getElementById("animation-rect").style.display === "block"
+          document.getElementById("animation-rect").style.visibility ===
+          "visible"
         ) {
           this.$root.$emit("checkIntersect");
         }
@@ -262,7 +263,7 @@ export default {
 
 <style scoped>
 #animation-rect {
-  display: none;
+  display: block;
   width: 100vw;
   height: 56.25vw; /* height:width ratio = 9/16 = .5625  */
   border: 4px solid red;
@@ -276,6 +277,7 @@ export default {
   right: 0; /* horizontal center */
   z-index: 1;
   pointer-events: none !important;
+  visibility: hidden;
 }
 #animation-rect::before {
   content: "";

--- a/src/components/Map/LegendControls.vue
+++ b/src/components/Map/LegendControls.vue
@@ -95,7 +95,8 @@ export default {
 
       if (event.target.classList.contains("resizable")) {
         if (
-          document.getElementById("animation-rect").style.display === "block"
+          document.getElementById("animation-rect").style.visibility ===
+          "visible"
         ) {
           if (event.type === "touchstart") {
             document.addEventListener("touchend", this.onResizeEnd);
@@ -151,7 +152,9 @@ export default {
       document.onmousemove = null;
       document.ontouchmove = null;
       document.ontouchend = null;
-      if (document.getElementById("animation-rect").style.display === "block") {
+      if (
+        document.getElementById("animation-rect").style.visibility === "visible"
+      ) {
         this.checkIntersect();
       }
     },

--- a/src/components/Map/SidePanel.vue
+++ b/src/components/Map/SidePanel.vue
@@ -166,15 +166,17 @@ export default {
     togglePreview(on) {
       let controlElement = document.getElementById("animation-rect");
       if (on) {
-        controlElement.style.display = "block";
+        controlElement.style.visibility = "visible";
         this.$root.$emit("checkIntersect");
       } else {
-        controlElement.style.display = "none";
+        controlElement.style.visibility = "hidden";
       }
     },
     updateScreenSize() {
       this.screenWidth = window.innerWidth;
-      if (document.getElementById("animation-rect").style.display === "block") {
+      if (
+        document.getElementById("animation-rect").style.visibility === "visible"
+      ) {
         this.$root.$emit("checkIntersect");
       }
     },


### PR DESCRIPTION
- Change `display: none` to `visibility:hidden` so that the animation preview's size doesn't go to 0x0 when it disappears. Otherwise this would make legends disappear from the animation output whenever you changed the tab while it was being made.