### PR TITLE
Fixed formatting issues with dates and screen sizes

### DIFF
--- a/src/components/Animation/AnimationConfiguration.vue
+++ b/src/components/Animation/AnimationConfiguration.vue
@@ -425,12 +425,12 @@ export default {
 .title-field::v-deep .v-label--active {
   display: none;
 }
-@media (max-width: 1265px) {
+@media (max-width: 1120px) {
   .scroll {
-    max-height: calc(100vh - (34px + 0.5em * 2) - 0.5em - 138px - 48px - 42px);
+    max-height: calc(100vh - (34px + 0.5em * 2) - 0.5em - 138px - 48px + 24px);
   }
 }
-@media (max-width: 1120px) {
+@media (max-width: 959px) {
   .scroll {
     max-height: calc(
       100vh - (34px + 0.5em * 2) - 0.5em - 138px - 48px - 42px + 24px

--- a/src/components/Layers/LayerConfiguration.vue
+++ b/src/components/Layers/LayerConfiguration.vue
@@ -196,12 +196,12 @@ export default {
   margin: 0;
   padding: 0;
 }
-@media (max-width: 1265px) {
+@media (max-width: 1120px) {
   .scroll {
-    max-height: calc(100vh - (34px + 0.5em * 2) - 0.5em - 138px - 48px - 42px);
+    max-height: calc(100vh - (34px + 0.5em * 2) - 0.5em - 138px - 48px + 24px);
   }
 }
-@media (max-width: 1120px) {
+@media (max-width: 959px) {
   .scroll {
     max-height: calc(
       100vh - (34px + 0.5em * 2) - 0.5em - 138px - 48px - 42px + 24px

--- a/src/components/Layers/LayerTree.vue
+++ b/src/components/Layers/LayerTree.vue
@@ -330,12 +330,12 @@ export default {
 .treeview::v-deep .v-treeview-node__prepend {
   margin-right: 0;
 }
-@media (max-width: 1265px) {
+@media (max-width: 1120px) {
   .treeview {
-    max-height: calc(100vh - (34px + 0.5em * 2) - 138px - 190px - 42px);
+    max-height: calc(100vh - (34px + 0.5em * 2) - 138px - 190px + 24px);
   }
 }
-@media (max-width: 1120px) {
+@media (max-width: 959px) {
   .treeview {
     max-height: calc(100vh - (34px + 0.5em * 2) - 138px - 190px - 42px + 24px);
   }

--- a/src/components/Map/GlobalConfigs.vue
+++ b/src/components/Map/GlobalConfigs.vue
@@ -1,16 +1,16 @@
 <template>
   <v-container fluid id="global_configs">
     <v-row class="align-center ma-0 justify-space-between">
-      <v-col cols="0" lg="4" class="pa-0"></v-col>
-      <v-col cols="12" lg="4" class="pa-0 pt-2">
+      <v-col cols="0" md="4" class="pa-0"></v-col>
+      <v-col cols="12" md="4" class="pa-0 pt-2">
         <animet-logo />
       </v-col>
       <v-col
         cols="12"
-        lg="4"
+        md="4"
         class="d-flex pa-0 pt-2 justify-center align-center"
       >
-        <v-spacer v-if="$vuetify.breakpoint.lgAndUp"></v-spacer>
+        <v-spacer v-if="$vuetify.breakpoint.mdAndUp"></v-spacer>
         <map-customization class="mr-3" />
         <page-theme class="mr-3" />
         <language-select class="mr-3" />

--- a/src/components/Map/LegendControls.vue
+++ b/src/components/Map/LegendControls.vue
@@ -229,7 +229,7 @@ export default {
   object-fit: contain;
   vertical-align: middle;
 }
-@media (max-width: 1265px) {
+@media (max-width: 959px) {
   .resizable {
     top: 100px;
   }

--- a/src/components/Map/MapCanvas.vue
+++ b/src/components/Map/MapCanvas.vue
@@ -586,20 +586,11 @@ export default {
   bottom: 18px;
 }
 @media (max-width: 1120px) {
-  .scale-line-collapsed {
-    bottom: 65px;
-  }
   .scale-line-open {
     bottom: 132px;
   }
-  .rotate-collapsed {
-    bottom: 92px;
-  }
   .rotate-open {
     bottom: 159px;
-  }
-  .attribution-collapsed {
-    bottom: 46px !important;
   }
   .attribution-open {
     bottom: 114px !important;
@@ -646,9 +637,6 @@ export default {
   font-size: 10px;
 }
 @media (max-width: 1120px) {
-  .animet-version-collapsed {
-    bottom: 49px !important;
-  }
   .animet-version-open {
     bottom: 116px !important;
   }

--- a/src/components/Map/OLControls.vue
+++ b/src/components/Map/OLControls.vue
@@ -86,14 +86,8 @@ export default {
   .zoom-plus-open {
     bottom: 170px;
   }
-  .zoom-plus-collapsed {
-    bottom: 103px;
-  }
   .zoom-minus-open {
     bottom: 138px;
-  }
-  .zoom-minus-collapsed {
-    bottom: 71px;
   }
 }
 @media (max-width: 565px) {

--- a/src/components/Map/SidePanel.vue
+++ b/src/components/Map/SidePanel.vue
@@ -250,19 +250,19 @@ export default {
   max-height: calc(100vh - (34px + 0.5em * 2) - 0.5em - 138px);
   overflow: hidden;
 }
-@media (max-width: 1265px) {
+@media (max-width: 1120px) {
+  .v-menu__content {
+    max-height: calc(100vh - (34px + 0.5em * 2) - 0.5em - 138px + 24px);
+  }
+}
+@media (max-width: 959px) {
   .v-menu__content {
     top: calc(34px + 42px + 0.5em * 2) !important;
-    max-height: calc(100vh - (34px + 0.5em * 2) - 0.5em - 138px - 42px);
+    max-height: calc(100vh - (34px + 0.5em * 2) - 0.5em - 138px - 42px + 24px);
   }
   .move-transition-enter,
   .move-transition-leave-to {
     transform: translateY(calc(-50vh + 92px)) !important;
-  }
-}
-@media (max-width: 1120px) {
-  .v-menu__content {
-    max-height: calc(100vh - (34px + 0.5em * 2) - 0.5em - 138px - 42px + 24px);
   }
 }
 @media (max-width: 565px) {

--- a/src/components/Time/TimeControls.vue
+++ b/src/components/Time/TimeControls.vue
@@ -1,7 +1,10 @@
 <template>
   <v-card
     id="time-controls"
-    :class="getCollapsedControls ? 'time-controls-collapsed' : ''"
+    :class="{
+      'time-controls-collapsed': getCollapsedControls,
+      'time-controls': !getCollapsedControls || screenWidth < 565,
+    }"
   >
     <div class="controller-padding" v-if="getMapTimeSettings.Step !== null">
       <div v-if="screenWidth >= 565">
@@ -22,6 +25,19 @@
           "
         >
           <v-icon v-if="!getCollapsedControls" large> mdi-chevron-down </v-icon>
+          <div
+            v-else-if="
+              getMapTimeSettings.Step === 'P1M' ||
+              getMapTimeSettings.Step === 'P1Y'
+            "
+          >
+            <span class="collapsed-date-M-Y">{{
+              this.localeDateFormat(
+                getMapTimeSettings.Extent[getMapTimeSettings.DateIndex],
+                getMapTimeSettings.Step
+              )
+            }}</span>
+          </div>
           <div v-else>
             <span class="collapsed-date">{{
               getCollapsedDateFormat()[0]
@@ -50,6 +66,19 @@
           "
         >
           <v-icon v-if="!getCollapsedControls" large> mdi-chevron-down </v-icon>
+          <div
+            v-else-if="
+              getMapTimeSettings.Step === 'P1M' ||
+              getMapTimeSettings.Step === 'P1Y'
+            "
+          >
+            <span class="collapsed-date-M-Y">{{
+              this.localeDateFormat(
+                getMapTimeSettings.Extent[getMapTimeSettings.DateIndex],
+                getMapTimeSettings.Step
+              )
+            }}</span>
+          </div>
           <div v-else>
             <span class="collapsed-date">{{
               getCollapsedDateFormat()[0]
@@ -431,12 +460,17 @@ export default {
 
 <style scoped>
 .collapsed {
-  border-radius: 0;
+  border-radius: 4px 4px 0 0;
   box-shadow: none;
-  margin-top: 6px;
-  transform: translateY(-13px);
-  width: 100%;
   height: 50px !important;
+  margin-top: 6px;
+  min-width: 255px !important;
+  pointer-events: auto;
+  transform: translateY(10px);
+  width: 30%;
+}
+.collapsed::before {
+  min-width: 250px;
 }
 .collapsed-date {
   display: block;
@@ -447,6 +481,12 @@ export default {
 .collapsed-time {
   display: block;
   font-size: 24px;
+  text-transform: none !important;
+  white-space: nowrap !important;
+}
+.collapsed-date-M-Y {
+  display: block;
+  font-size: 26px;
   text-transform: none !important;
   white-space: nowrap !important;
 }
@@ -461,62 +501,57 @@ export default {
   background-color: transparent !important;
   border-radius: 0;
   box-shadow: none;
+  height: 26px !important;
   margin-top: 6px;
   transform: translateY(-13px);
   width: 100%;
-  height: 26px !important;
 }
 .hide-controls {
   display: none;
 }
 .slider {
-  padding-top: 2px;
   padding-bottom: 0;
+  padding-top: 2px;
 }
 #collapse-button::v-deep .v-btn__content {
   height: 20px;
 }
 #time-controls {
-  position: absolute;
-  bottom: 24px;
-  width: 75%;
-  left: 50%;
-  transform: translateX(-50%);
   border-radius: 20px;
+  bottom: 24px;
+  left: 50%;
   max-width: 1200px;
+  position: absolute;
+  text-align: center;
+  transform: translateX(-50%);
+  width: 75%;
   z-index: 2;
 }
-@media (min-width: 1121px) {
-  .collapsed {
-    pointer-events: auto;
-    border-radius: 4px 4px 0 0;
-    box-shadow: none;
-    margin-left: calc(35%);
-    transform: translateY(10px);
-    width: 30%;
-    height: 50px !important;
+@media (max-width: 1120px) {
+  .time-controls {
+    border-radius: 0 !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    right: 0 !important;
+    transform: none !important;
+    width: 100% !important;
   }
+}
+@media (min-width: 565px) {
   .time-controls-collapsed {
     background-color: transparent;
     box-shadow: none !important;
-    pointer-events: none !important;
     padding-top: 0;
-  }
-}
-@media (max-width: 1120px) {
-  #time-controls {
-    width: 100%;
-    transform: none;
-    border-radius: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    pointer-events: none !important;
   }
 }
 @media (max-width: 565px) {
   .collapsed {
+    border-radius: 0;
+    margin-left: 0;
     margin-top: -8px;
     transform: translateY(-4px);
+    width: 100%;
   }
   .controller-padding {
     pointer-events: auto;


### PR DESCRIPTION
- Global icons on the top right now wait for md screen size (960px) instead of lg (1264px) before moving under the AniMet logo;
- Fixed some slight adjustments issues with menu sizes during resize;
- Made it so the collapsed time controls stay small for as long as possible;
- Adjusted screen elements to match collapsed controls new positioning;
- Collapsed time controls now display the time in the correct format when timestep is monthly or yearly.