### PR TITLE
Multiple bugfixes and small improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "axios": "^0.26.0",
+        "axios-retry": "^4.4.0",
         "canvas-txt": "^3.0.0",
         "core-js": "^3.6.5",
         "countries-and-timezones": "^3.5.1",
@@ -3398,6 +3399,17 @@
       "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
       "dependencies": {
         "follow-redirects": "^1.14.8"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.4.0.tgz",
+      "integrity": "sha512-yewTKjzl6jSgc+2M7FCJ3LxRGgL1iiXHcj+E6h6xie6H1mTHr7yqaUroWIvVXG1UKSPwGDXxV05YxtGvrD6Paw==",
+      "dependencies": {
+        "is-retry-allowed": "^2.2.0"
+      },
+      "peerDependencies": {
+        "axios": "0.x || 1.x"
       }
     },
     "node_modules/babel-eslint": {
@@ -7206,6 +7218,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-stream": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "axios": "^0.26.0",
+    "axios-retry": "^4.4.0",
     "canvas-txt": "^3.0.0",
     "core-js": "^3.6.5",
     "countries-and-timezones": "^3.5.1",

--- a/src/components/Animation/AnimationConfiguration.vue
+++ b/src/components/Animation/AnimationConfiguration.vue
@@ -33,7 +33,11 @@
         </v-switch>
         <v-switch
           class="reverse-switch"
-          :disabled="isAnimating"
+          :disabled="
+            isAnimating ||
+            datetimeRangeSlider[0] === datetimeRangeSlider[1] ||
+            getOutputFormat !== 'MP4'
+          "
           v-model="animationReversed"
           hide-details
           :label="$t('ReverseAnimation')"
@@ -60,7 +64,11 @@
         </v-select>
         <v-text-field
           hide-details
-          :disabled="isAnimating"
+          :disabled="
+            isAnimating ||
+            datetimeRangeSlider[0] === datetimeRangeSlider[1] ||
+            getOutputFormat !== 'MP4'
+          "
           v-model="framesPerSecond"
           type="number"
           min="1"
@@ -84,7 +92,9 @@
           v-model="outputFormat"
           :label="$t('OutputFormat')"
           :items="outputOptions"
-          :disabled="isAnimating"
+          :disabled="
+            isAnimating || datetimeRangeSlider[0] === datetimeRangeSlider[1]
+          "
         >
         </v-select>
       </v-row>
@@ -289,7 +299,11 @@ export default {
       "getMP4URL",
       "getOutputFormat",
     ]),
-    ...mapState("Layers", ["isAnimating", "isAnimationReversed"]),
+    ...mapState("Layers", [
+      "datetimeRangeSlider",
+      "isAnimating",
+      "isAnimationReversed",
+    ]),
     animationReversed: {
       get() {
         return this.isAnimationReversed;

--- a/src/components/Layers/LayerTree.vue
+++ b/src/components/Layers/LayerTree.vue
@@ -129,7 +129,7 @@
 </template>
 
 <script>
-import axios from "axios";
+import axios from "../../utils/AxiosConfig.js";
 import SaxonJS from "saxon-js";
 import { mapGetters, mapState } from "vuex";
 

--- a/src/components/Time/AutoRefresh.vue
+++ b/src/components/Time/AutoRefresh.vue
@@ -1,7 +1,7 @@
 <template></template>
 
 <script>
-import axios from "axios";
+import axios from "../../utils/AxiosConfig.js";
 import SaxonJS from "saxon-js";
 
 import { mapState } from "vuex";

--- a/src/components/Time/ErrorManager.vue
+++ b/src/components/Time/ErrorManager.vue
@@ -56,7 +56,7 @@
 </template>
 
 <script>
-import axios from "axios";
+import axios from "../../utils/AxiosConfig.js";
 import { mapGetters, mapState } from "vuex";
 import SaxonJS from "saxon-js";
 
@@ -242,8 +242,9 @@ export default {
             layerStartTime: newExtent[0],
             layerEndTime: newExtent[newExtent.length - 1],
           });
-          this.errorLayersList = this.errorLayersList.filter(
-            (l) => l !== layer.get("layerName")
+          this.errorLayersList.splice(
+            this.errorLayersList.indexOf(layer.get("layerName")),
+            1
           );
         } else if (
           "code" in attrs &&
@@ -253,8 +254,9 @@ export default {
           this.expiredSnackBarMessage = this.$t("StyleError");
           this.timeoutDuration = 8000;
           this.notifyExtentRebuilt = true;
-          this.errorLayersList = this.errorLayersList.filter(
-            (l) => l !== layer.get("layerName")
+          this.errorLayersList.splice(
+            this.errorLayersList.indexOf(layer.get("layerName")),
+            1
           );
         } else {
           this.$root.$emit("cancelExpired");
@@ -263,8 +265,9 @@ export default {
           console.error("Unhandled error case: ", response);
           this.timeoutDuration = 12000;
           this.notifyExtentRebuilt = true;
-          this.errorLayersList = this.errorLayersList.filter(
-            (l) => l !== layer.get("layerName")
+          this.errorLayersList.splice(
+            this.errorLayersList.indexOf(layer.get("layerName")),
+            1
           );
         }
       } catch (error) {
@@ -295,8 +298,9 @@ export default {
         this.expiredSnackBarMessage = this.$t("BrokenLayer");
         this.timeoutDuration = 12000;
         this.notifyExtentRebuilt = true;
-        this.errorLayersList = this.errorLayersList.filter(
-          (l) => l !== layer.get("layerName")
+        this.errorLayersList.splice(
+          this.errorLayersList.indexOf(layer.get("layerName")),
+          1
         );
       }
     },
@@ -402,8 +406,9 @@ export default {
         layerTimeStep: configs[layerActiveConfig].layerTimeStep,
         layerTrueTimeStep: configs[layerActiveConfig].layerTrueTimeStep,
       });
-      this.errorLayersList = this.errorLayersList.filter(
-        (l) => l !== layer.get("layerName")
+      this.errorLayersList.splice(
+        this.errorLayersList.indexOf(layer.get("layerName")),
+        1
       );
     },
   },

--- a/src/components/Time/TimeControls.vue
+++ b/src/components/Time/TimeControls.vue
@@ -244,8 +244,7 @@ export default {
           // Trigger manually because animation creation waits for
           // render events, but noChange means no layers are shown
           // so nothing ever changes or renders.
-          this.$root.$emit("layersRendered");
-          this.$animationCanvas.mapObj.updateSize();
+          this.$root.$emit("noChange");
         }
         return;
       }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -52,6 +52,7 @@
   "LoopRetry": "Service unavailable. Retrying in 45 seconds.",
   "MadeWithAniMet": "Made with MSC AniMet",
   "Major_cities": "Canadian cities",
+  "MakeLayersVisible": "All layers are invisible, no animation/image can be created.",
   "MapCustomizations": "Customize map",
   "MissingTimesteps": "Some timesteps have expired. The temporal values have been updated.",
   "ModelRun": "Model run",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -52,6 +52,7 @@
   "LoopRetry": "Service non disponible. Nouvelle tentative dans 45 secondes.",
   "MadeWithAniMet": "Créé avec AniMet du SMC",
   "Major_cities": "Villes canadiennes",
+  "MakeLayersVisible": "Toutes les couches sont invisibles, aucune animation/image ne peut être créée.",
   "MapCustomizations": "Personnaliser la carte",
   "MissingTimesteps": "Certains pas de temps ont expiré. Les informations temporelles ont été mises à jour.",
   "ModelRun": "Passe du modèle",

--- a/src/utils/AxiosConfig.js
+++ b/src/utils/AxiosConfig.js
@@ -1,0 +1,11 @@
+import axios from "axios";
+import axiosRetry from "axios-retry";
+
+axiosRetry(axios, {
+  retries: 4,
+  retryDelay: (retryCount) => {
+    return retryCount * 800;
+  },
+});
+
+export default axios;


### PR DESCRIPTION
- Added axios-retry library to make axios retry 4 times taking longer and longer between retries to try and reduce odds of failure on timeouts and such (which in a loop is handled but takes 45sec to retry so this should still be better). Hard to test though so will need to see if it introduces any kind of errors;
- Animate in reverse switch, fps selector and output format selector disabled when start === end (single frame animation turns into image) and reverse switch, fps selector disabled also when output format is not MP4;
- Create animation/image button now disabled when all the layers are set invisible and tooltip appears over it only when disabled (previously would do nothing without telling the user why);
- It seems `updateSize()` no longer triggered the `rendercomplete` event, so instead a `noChange` event was added to trigger the promise when the map is waiting for layers and map render when no layers are displayed (example some layers invisible and only visible layer has red-eye icon);
- During an animation, both layernames from animation canvas and map canvas get added to the `errorLayersList`. Fixed a bug where `errorHandler` would filter out by `layerName` which would remove both whenever only one of them was fixed.