### PR TITLE
Bugfixes for 2.2.1

### DIFF
--- a/src/components/Animation/AnimationCanvas.vue
+++ b/src/components/Animation/AnimationCanvas.vue
@@ -23,7 +23,6 @@ import "ol/ol.css";
 export default {
   data() {
     return {
-      cancelExpired: false,
       copiedLayers: [],
       darkOSMCallback: null,
       loaded: 0,
@@ -33,12 +32,10 @@ export default {
   mixins: [datetimeManipulations],
   mounted() {
     this.$root.$on("animationCanvasReset", this.mapControls);
-    this.$root.$on("cancelExpired", this.handleCancelExpired);
     this.animationCanvasSetup();
   },
   beforeDestroy() {
     this.$root.$off("animationCanvasReset", this.mapControls);
-    this.$root.$off("cancelExpired", this.handleCancelExpired);
     this.removeLayersListeners();
     this.$animationCanvas.mapObj = {};
   },
@@ -246,9 +243,6 @@ export default {
         }
       });
     },
-    handleCancelExpired() {
-      this.cancelExpired = true;
-    },
     incrementLoadedCount() {
       this.loaded++;
     },
@@ -256,7 +250,6 @@ export default {
       this.loading++;
     },
     async mapControls() {
-      this.cancelExpired = false;
       const driverDate =
         this.getMapTimeSettings.Extent[this.getMapTimeSettings.DateIndex];
       let visibleTLayers = this.copiedLayers.filter((l) => {

--- a/src/components/Time/AnimationControls/PlayPauseControls.vue
+++ b/src/components/Time/AnimationControls/PlayPauseControls.vue
@@ -34,9 +34,6 @@ import ControllerOptions from "./ControllerOptions.vue";
 
 export default {
   mounted() {
-    this.$root.$on("cancelCriticalError", (isError) => {
-      this.cancelCriticalError = isError;
-    });
     this.$root.$on("playAnimation", this.play);
     this.$root.$on("stopAnimation", this.playPause);
   },
@@ -49,7 +46,6 @@ export default {
   },
   data() {
     return {
-      cancelCriticalError: false,
       locked: false,
       loop: false,
       playbackReversed: false,
@@ -60,7 +56,11 @@ export default {
   },
   computed: {
     ...mapGetters("Layers", ["getDatetimeRangeSlider", "getMapTimeSettings"]),
-    ...mapState("Layers", ["isAnimating", "playState"]),
+    ...mapState("Layers", [
+      "isAnimating",
+      "pendingErrorResolution",
+      "playState",
+    ]),
     changeIcon() {
       let replayCondition;
       if (this.playbackReversed) {
@@ -188,7 +188,7 @@ export default {
               this.$mapCanvas.mapObj.once("rendercomplete", resolve)
             )
         );
-        if (!this.cancelCriticalError && this.playState === "play") {
+        if (!this.pendingErrorResolution && this.playState === "play") {
           if (r < 1000) {
             await this.delay(1000 - r);
           }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -49,7 +49,7 @@
   "Loading": "Loading...",
   "LocalTime": "Local",
   "Loop": "Loop",
-  "LoopRetry": "Service unavailable. Retrying in 45 seconds.",
+  "LoopRetry": "Service unavailable. Retrying in 20 seconds.",
   "MadeWithAniMet": "Made with MSC AniMet",
   "Major_cities": "Canadian cities",
   "MakeLayersVisible": "All layers are invisible, no animation/image can be created.",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -49,7 +49,7 @@
   "Loading": "Chargement...",
   "LocalTime": "Local",
   "Loop": "Lecture en boucle",
-  "LoopRetry": "Service non disponible. Nouvelle tentative dans 45 secondes.",
+  "LoopRetry": "Service non disponible. Nouvelle tentative dans 20 secondes.",
   "MadeWithAniMet": "Créé avec AniMet du SMC",
   "Major_cities": "Villes canadiennes",
   "MakeLayersVisible": "Toutes les couches sont invisibles, aucune animation/image ne peut être créée.",

--- a/src/store/modules/Layers.js
+++ b/src/store/modules/Layers.js
@@ -89,6 +89,7 @@ const state = {
       isShown: false,
     },
   },
+  pendingErrorResolution: false,
   permalink: null,
   playState: "pause",
   resolution: "1080p",
@@ -320,6 +321,9 @@ const mutations = {
     return (state.overlays[overlay]["isShown"] =
       !state.overlays[overlay]["isShown"]);
   },
+  setPendingErrorResolution: (state, isPending) => {
+    state.pendingErrorResolution = isPending;
+  },
   setPermalink: (state, permalink) => {
     state.permalink = permalink;
   },
@@ -435,6 +439,9 @@ const actions = {
   },
   setOverlayDisplayed({ commit }, payload) {
     commit("setOverlayDisplayed", payload);
+  },
+  setPendingErrorResolution({ commit }, payload) {
+    commit("setPendingErrorResolution", payload);
   },
   setPermalink({ commit }, payload) {
     commit("setPermalink", payload);


### PR DESCRIPTION
- Fixed panels freezing during a loop if the connection is particularly unstable;
- Fixed animation creation crashing during error handling;
- Fixed layers getting removed from AniMet during idle or animation creation during connection errors;
- Removed no longer used `cancelExpired` flag from animation canvas;
- Error list properly resets however many times a layer triggers an error;
- Changed error retry to every 20 sec instead of 45;
- Auto-refresh disabled during animation creation;
- Fixed time continuing to move forward during critical error because critical error flag wasn't triggered fast enough;
- Added error handling if error happens during the refresh query and not in the initial query.