### PR TITLE
Added Play Pause to the collapsed controls and fixed component remounting bug

### DIFF
--- a/src/components/Time/AnimationControls/ControllerOptions.vue
+++ b/src/components/Time/AnimationControls/ControllerOptions.vue
@@ -3,6 +3,7 @@
     <template v-slot:activator="{ on, attrs }">
       <v-btn
         class="controller-options"
+        :class="hide ? 'hide-controls' : ''"
         color="primary"
         small
         v-bind="attrs"
@@ -44,6 +45,9 @@
 import { mapState } from "vuex";
 
 export default {
+  props: {
+    hide: Boolean,
+  },
   mounted() {
     this.$nextTick(() => {
       if (this.isLooping) {
@@ -69,6 +73,9 @@ export default {
 }
 .controller-options-icon {
   font-size: 20px !important;
+}
+.hide-controls {
+  display: none;
 }
 .options-card {
   min-width: 150px;

--- a/src/components/Time/TimeControls.vue
+++ b/src/components/Time/TimeControls.vue
@@ -12,83 +12,108 @@
           class="mr-1 ml-1 pt-2 pb-1 px-0"
           :class="getCollapsedControls ? 'hide-controls' : ''"
         >
-          <time-slider class="enable-events" />
+          <time-slider :hide="getCollapsedControls" class="enable-events" />
           <interval-locale-selector class="enable-events" />
         </v-row>
-        <v-btn
-          id="collapse-button"
-          class="enable-events"
-          :class="getCollapsedControls ? 'collapsed' : 'extended'"
-          small
-          @click="
-            $store.commit('Layers/setCollapsedControls', !getCollapsedControls)
-          "
-        >
-          <v-icon v-if="!getCollapsedControls" large> mdi-chevron-down </v-icon>
-          <div
-            v-else-if="
-              getMapTimeSettings.Step === 'P1M' ||
-              getMapTimeSettings.Step === 'P1Y'
+        <div>
+          <play-pause-controls
+            v-if="getCollapsedControls"
+            :hide="getCollapsedControls"
+            class="collapsed-play-pause"
+          ></play-pause-controls>
+          <v-btn
+            id="collapse-button"
+            class="enable-events"
+            :class="getCollapsedControls ? 'collapsed' : 'extended'"
+            small
+            @click="
+              $store.commit(
+                'Layers/setCollapsedControls',
+                !getCollapsedControls
+              )
             "
           >
-            <span class="collapsed-date-M-Y">{{
-              this.localeDateFormat(
-                getMapTimeSettings.Extent[getMapTimeSettings.DateIndex],
-                getMapTimeSettings.Step
-              )
-            }}</span>
-          </div>
-          <div v-else>
-            <span class="collapsed-date">{{
-              getCollapsedDateFormat()[0]
-            }}</span>
-            <span class="collapsed-time">{{
-              getCollapsedDateFormat()[1]
-            }}</span>
-          </div>
-        </v-btn>
+            <v-icon v-if="!getCollapsedControls" large>
+              mdi-chevron-down
+            </v-icon>
+            <div
+              v-else-if="
+                getMapTimeSettings.Step === 'P1M' ||
+                getMapTimeSettings.Step === 'P1Y'
+              "
+            >
+              <span class="collapsed-date-M-Y">{{
+                this.localeDateFormat(
+                  getMapTimeSettings.Extent[getMapTimeSettings.DateIndex],
+                  getMapTimeSettings.Step
+                )
+              }}</span>
+            </div>
+            <div v-else>
+              <span class="collapsed-date">{{
+                getCollapsedDateFormat()[0]
+              }}</span>
+              <span class="collapsed-time">{{
+                getCollapsedDateFormat()[1]
+              }}</span>
+            </div>
+          </v-btn>
+        </div>
       </div>
-      <v-col class="mr-1 pt-2 pb-2 px-0" v-else>
-        <time-slider
-          class="enable-events slider"
-          :class="getCollapsedControls ? 'hide-controls' : ''"
-        />
-        <interval-locale-selector
-          class="enable-events"
-          :class="getCollapsedControls ? 'hide-controls' : ''"
-        />
-        <v-btn
-          class="enable-events"
-          :class="getCollapsedControls ? 'collapsed' : 'extended'"
-          small
-          @click="
-            $store.commit('Layers/setCollapsedControls', !getCollapsedControls)
-          "
-        >
-          <v-icon v-if="!getCollapsedControls" large> mdi-chevron-down </v-icon>
-          <div
-            v-else-if="
-              getMapTimeSettings.Step === 'P1M' ||
-              getMapTimeSettings.Step === 'P1Y'
+      <div v-else>
+        <play-pause-controls
+          v-if="getCollapsedControls"
+          :hide="getCollapsedControls"
+          class="collapsed-play-pause-small"
+        ></play-pause-controls>
+        <v-col class="mr-1 pt-2 pb-2 px-0">
+          <time-slider
+            class="enable-events slider"
+            :class="getCollapsedControls ? 'hide-controls' : ''"
+            :hide="getCollapsedControls"
+          />
+          <interval-locale-selector
+            class="enable-events"
+            :class="getCollapsedControls ? 'hide-controls' : ''"
+          />
+          <v-btn
+            class="enable-events"
+            :class="getCollapsedControls ? 'collapsed' : 'extended'"
+            small
+            @click="
+              $store.commit(
+                'Layers/setCollapsedControls',
+                !getCollapsedControls
+              )
             "
           >
-            <span class="collapsed-date-M-Y">{{
-              this.localeDateFormat(
-                getMapTimeSettings.Extent[getMapTimeSettings.DateIndex],
-                getMapTimeSettings.Step
-              )
-            }}</span>
-          </div>
-          <div v-else>
-            <span class="collapsed-date">{{
-              getCollapsedDateFormat()[0]
-            }}</span>
-            <span class="collapsed-time">{{
-              getCollapsedDateFormat()[1]
-            }}</span>
-          </div>
-        </v-btn>
-      </v-col>
+            <v-icon v-if="!getCollapsedControls" large>
+              mdi-chevron-down
+            </v-icon>
+            <div
+              v-else-if="
+                getMapTimeSettings.Step === 'P1M' ||
+                getMapTimeSettings.Step === 'P1Y'
+              "
+            >
+              <span class="collapsed-date-M-Y">{{
+                this.localeDateFormat(
+                  getMapTimeSettings.Extent[getMapTimeSettings.DateIndex],
+                  getMapTimeSettings.Step
+                )
+              }}</span>
+            </div>
+            <div v-else>
+              <span class="collapsed-date">{{
+                getCollapsedDateFormat()[0]
+              }}</span>
+              <span class="collapsed-time">{{
+                getCollapsedDateFormat()[1]
+              }}</span>
+            </div>
+          </v-btn>
+        </v-col>
+      </div>
     </div>
     <error-manager />
   </v-card>
@@ -101,12 +126,14 @@ import datetimeManipulations from "../../mixins/datetimeManipulations";
 
 import ErrorManager from "./ErrorManager.vue";
 import IntervalLocaleSelector from "./IntervalLocaleSelector.vue";
+import PlayPauseControls from "./AnimationControls/PlayPauseControls.vue";
 import TimeSlider from "./TimeSlider.vue";
 
 export default {
   components: {
     ErrorManager,
     IntervalLocaleSelector,
+    PlayPauseControls,
     TimeSlider,
   },
   mixins: [datetimeManipulations],
@@ -464,13 +491,28 @@ export default {
   box-shadow: none;
   height: 50px !important;
   margin-top: 6px;
-  min-width: 255px !important;
+  min-width: 285px !important;
   pointer-events: auto;
   transform: translateY(10px);
   width: 30%;
 }
 .collapsed::before {
   min-width: 250px;
+}
+.collapsed-play-pause {
+  display: flex;
+  position: relative;
+  min-width: 285px !important;
+  width: 30%;
+  margin-left: auto;
+  margin-right: auto;
+  z-index: 2;
+  transform: translate(5px, 59px);
+}
+.collapsed-play-pause-small {
+  bottom: 4px;
+  position: absolute;
+  z-index: 2;
 }
 .collapsed-date {
   display: block;

--- a/src/components/Time/TimeSlider.vue
+++ b/src/components/Time/TimeSlider.vue
@@ -20,7 +20,10 @@
       </div>
     </v-row>
     <v-row>
-      <play-pause-controls class="play-pause"></play-pause-controls>
+      <play-pause-controls
+        v-if="!hide"
+        class="play-pause"
+      ></play-pause-controls>
       <v-col class="pl-0">
         <v-range-slider
           class="range_slider"
@@ -70,6 +73,9 @@ import ArrowControls from "./AnimationControls/ArrowControls.vue";
 import PlayPauseControls from "./AnimationControls/PlayPauseControls.vue";
 
 export default {
+  props: {
+    hide: Boolean,
+  },
   mixins: [datetimeManipulations],
   components: {
     ArrowControls,


### PR DESCRIPTION
- Play/Pause/Replay buttons now appear on the collapsed controls;
- When collapsed, icon changes to be simpler and a bit smaller to take less real estate;
- Fixed bug where unmounting component and remounting it while Playing the loop would cause the unmounted component to never stop and every time this would happen the loop would skip 1 more timestep (unnoticeable before since for this to happen you needed to press play and then reduce your screen to phone size).