### PR TITLE
Safeguard wms source errors

### DIFF
--- a/src/store/modules/Layers.js
+++ b/src/store/modules/Layers.js
@@ -1,6 +1,6 @@
 import { default as layerTrees } from "../../assets/trees";
 import Vue from "vue";
-import wmsSources from "../../../scripts/wms_sources_configs.json";
+import wmsSources from "../../assets/wms_sources_configs.json";
 
 import IntegerAssigner from "../../utils/IntegerAssigner.js";
 


### PR DESCRIPTION
This PR ensures that if errors are encountered when reading the GetCapabilities documents of services defined in the `scripts/wms_sources_configs.json` file, they are simply ignored instead of causing the layer tree generation to fail. The problematic source is removed from the sources list and a "cleaned" WMS sources JSON document is now added to the `src/assets` directory to be used by the `src/store/modules/Layer.js` module.