### PR TITLE
remove matomo analytics and events

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,25 +37,6 @@
           );
       }
     </script>
-    <% if (NODE_ENV === 'production') { %><!-- Matomo -->
-    <script>
-      var _paq = (window._paq = window._paq || []);
-      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-      _paq.push(["trackPageView"]);
-      _paq.push(["enableLinkTracking"]);
-      (function () {
-        var u = "https://msc-analytics.ca/piwik/";
-        _paq.push(["setTrackerUrl", u + "matomo.php"]);
-        _paq.push(["setSiteId", "7"]);
-        var d = document,
-          g = d.createElement("script"),
-          s = d.getElementsByTagName("script")[0];
-        g.async = true;
-        g.src = u + "matomo.js";
-        s.parentNode.insertBefore(g, s);
-      })();
-    </script>
-    <!-- End Matomo Code --><% } %>
 
     <!--
     MSC AniMet

--- a/src/components/Animation/CreateAnimation.vue
+++ b/src/components/Animation/CreateAnimation.vue
@@ -153,14 +153,8 @@ export default {
         );
       }
     },
-    trackCreateMP4() {
-      if (this.appIsProductionEnv === "production") {
-        _paq.push(["trackEvent", "Button", "Click", "Create animation"]);
-      }
-    },
     async createMP4() {
       this.$root.$emit("setAnimationTitle");
-      this.trackCreateMP4();
       this.createMP4Handler();
       this.outputDate = this.getOutputDate;
       this.$store.dispatch(


### PR DESCRIPTION
This PR removes Matomo tracking and events following the shutdown of the msc-analytics Matomo instance.