### PR TITLE
Fixed some time edge cases, layer tree failure and range slider styling

### DIFF
--- a/src/components/Animation/AnimationConfiguration.vue
+++ b/src/components/Animation/AnimationConfiguration.vue
@@ -16,7 +16,7 @@
         variant="underlined"
         clearable
         hide-details
-        @keydown.left.right.space.stop
+        @keydown.left.right.space.enter.stop
         :disabled="isAnimating"
         :label="$t('MP4CreateCustomTitle')"
       ></v-text-field>
@@ -74,7 +74,7 @@
           class="fps-selector"
           density="compact"
           variant="underlined"
-          @keydown.left.right.space.stop
+          @keydown.left.right.space.enter.stop
           @keydown.enter.stop
         >
           <template v-slot:label>

--- a/src/components/GlobalConfigs/Share/PermaLink.vue
+++ b/src/components/GlobalConfigs/Share/PermaLink.vue
@@ -32,7 +32,7 @@
             rounded
             single-line
             :value="[permalink ? permalink : prefixLink()]"
-            @keydown.left.right.space.stop
+            @keydown.left.right.space.enter.stop
           >
             <template v-slot:prepend>
               <v-btn

--- a/src/components/Layers/LayerTree.vue
+++ b/src/components/Layers/LayerTree.vue
@@ -47,7 +47,7 @@
               color="primary"
               density="compact"
               variant="underlined"
-              @keydown.left.right.space.stop
+              @keydown.left.right.space.enter.stop
               @input="debouncedFilterOnInput(index)"
               @click:clear="filterOnInput(index)"
             >
@@ -310,6 +310,12 @@ export default {
                   .getAttributeNS('http://www.w3.org/1999/xlink', 'href'),
               })
             }
+          } else {
+            this.addedLayers = this.addedLayers.filter(
+              (added) => added !== layer.Name,
+            )
+            this.emitter.emit('LayerQueryFailure')
+            throw new Error(`Query for ${layer.Name} failed`)
           }
         })
         layerData = { ...layerData, ...layer }

--- a/src/components/Map/MapCanvas.vue
+++ b/src/components/Map/MapCanvas.vue
@@ -367,7 +367,8 @@ export default {
         const layer = this.$mapLayers.arr.find(
           (l) => l.get('layerName') === e.target.getParams()['LAYERS'],
         )
-        this.emitter.emit('loadingError', { layer: layer, error: e })
+        if (layer !== undefined)
+          this.emitter.emit('loadingError', { layer: layer, error: e })
       })
 
       imageLayer.getSource().updateParams({

--- a/src/components/Time/LocaleSelector.vue
+++ b/src/components/Time/LocaleSelector.vue
@@ -42,7 +42,7 @@
             density="compact"
             variant="outlined"
             @input="filterOnInput()"
-            @keydown.left.right.space.stop
+            @keydown.left.right.space.enter.stop
             @click:clear="filterOnInput()"
           ></v-text-field>
           <tree-node

--- a/src/components/Time/TimeControls.vue
+++ b/src/components/Time/TimeControls.vue
@@ -220,10 +220,14 @@ export default {
       // Prevents a bug that triggers play twice
       const playStateBuffer = this.playState
 
-      const mapTime =
-        this.mapTimeSettings.Extent[this.mapTimeSettings.DateIndex]
-
       const numLayers = this.$mapLayers.arr.length
+
+      let mapTime
+      if (this.mapTimeSettings.Extent !== null) {
+        mapTime = this.mapTimeSettings.Extent[this.mapTimeSettings.DateIndex]
+      } else {
+        numLayers = 0
+      }
       let noChange = true
       for (let i = 0; i < numLayers; i++) {
         if (

--- a/src/components/Time/TimeSlider.vue
+++ b/src/components/Time/TimeSlider.vue
@@ -39,6 +39,7 @@
           :track-size="2"
           :thumb-label="false"
           hide-details
+          :elevation="datetimeRangeSlider[0] === datetimeRangeSlider[1] ? 0 : 2"
           @end="handleEnd"
           @update:model-value="changeDisplayedTime"
         ></v-range-slider>
@@ -247,6 +248,7 @@ export default {
     },
     thumbPosition() {
       const max = this.mapTimeSettings.Extent.length - 1
+      if (max === 0) return 0
       return (this.mapTimeSettings.DateIndex / max) * 100
     },
   },


### PR DESCRIPTION
- Layer tree no longer breaks when trying to query a layer that in unavailable and a snackbar will appear to let you know there's a problem;
- Fixed an edge case where if a layer was remove during handling of an error a loadingError would be sent with a layer with a value of undefined;
- Fixed an edge case where errors would loop indefinitely when a layer is removed during error handling;
- Layer will now be removed from AniMet when the error `Unable to access file` while not in a loop or animating instead of showing service unavailable;
- Fixed an edge case where the map time would try to update even though there were no time layers left;
- Fixed styling of the range slider when thumbs are overlapping (only noticeable when disabled like for single timestep layers like caldas);
- Fixed snapping layer not moving the playhead for extent lengths of 0 (like caldas).