### PR TITLE
Fixed invalid CRS handling and finicky auto tab switch

### DIFF
--- a/src/components/GlobalConfigs/MapCustomizations/CustomizationMenu.vue
+++ b/src/components/GlobalConfigs/MapCustomizations/CustomizationMenu.vue
@@ -82,7 +82,7 @@ export default {
         this.menuOpen = !this.menuOpen
         this.store.setMenusOpen(this.menuOpen)
         if (this.menuOpen) {
-          this.emitter.emit('collapseMenu')
+          this.emitter.emit('collapseMenu', false)
         }
       },
     },

--- a/src/components/Layers/LayerTree.vue
+++ b/src/components/Layers/LayerTree.vue
@@ -404,13 +404,6 @@ export default {
 .radius {
   border-radius: 0px;
 }
-.source-tabs {
-  flex: 1;
-  padding: 0 4px;
-}
-.source-tabs:deep(.v-btn__content) {
-  white-space: normal;
-}
 .subtitle {
   color: grey;
   display: block;
@@ -428,11 +421,6 @@ export default {
   max-height: calc(100vh - (34px + 0.5em * 2) - 138px - 190px);
   overflow-y: auto;
 }
-.v-tabs:deep(.v-slide-group__next),
-.v-tabs:deep(.v-slide-group__prev) {
-  flex: 0 1;
-  min-width: 30px;
-}
 @media (max-width: 1120px) {
   .treeview {
     max-height: calc(100vh - (34px + 0.5em * 2) - 138px - 190px + 24px);
@@ -444,11 +432,6 @@ export default {
   }
 }
 @media (max-width: 565px) {
-  .nightly-chip {
-    padding-left: 4px;
-    padding-right: 14px;
-    transform: translateX(-10px);
-  }
   .treeview {
     max-height: calc(100vh - (34px + 0.5em * 2) - 158px - 190px - 42px - 10px);
   }

--- a/src/components/Map/SidePanel.vue
+++ b/src/components/Map/SidePanel.vue
@@ -115,8 +115,8 @@ export default {
     })
     window.addEventListener('keydown', this.closeMenu)
     window.addEventListener('resize', this.updateScreenSize)
-    this.emitter.on('collapseMenu', () => {
-      if (!this.buttonShown) {
+    this.emitter.on('collapseMenu', (permalinkSetup) => {
+      if (permalinkSetup) {
         var unwatch = this.$watch(
           'layersLength',
           (_, oldVal) => {
@@ -127,6 +127,8 @@ export default {
           },
           { immediate: true },
         )
+      }
+      if (!this.buttonShown) {
         this.buttonShown = true
         this.menuOpen = false
       }

--- a/src/components/Time/ErrorManager.vue
+++ b/src/components/Time/ErrorManager.vue
@@ -295,6 +295,19 @@ export default {
             this.errorLayersList.indexOf(layer.get('layerName')),
             1,
           )
+        } else if (
+          'code' in attrs &&
+          attrs['code'].nodeValue === 'InvalidSRS'
+        ) {
+          this.emitter.emit('removeLayer', layer)
+          this.expiredSnackBarMessage = this.t('InvalidSRS', {
+            CRS: this.currentCRS,
+          })
+          this.timeoutDuration = 8000
+          this.errorLayersList.splice(
+            this.errorLayersList.indexOf(layer.get('layerName')),
+            1,
+          )
         } else {
           this.emitter.emit('removeLayer', layer)
           this.expiredSnackBarMessage = this.t('UnhandledError')
@@ -518,6 +531,9 @@ export default {
     },
   },
   computed: {
+    currentCRS() {
+      return this.store.getCurrentCRS
+    },
     datetimeRangeSlider() {
       return this.store.getDatetimeRangeSlider
     },

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -32,6 +32,7 @@
   "GeoMetWms": "Add {wmsSource} layers",
   "GoToHomePage": "Go to MSC AniMet home page",
   "Grey": "Grey",
+  "InvalidSRS": "CRS {CRS} is invalid for this data source.",
   "JPEGCreateButtonLabel": "Create image",
   "JPEGExportDownload": "Download as JPEG",
   "JPEGExportSubtitle": "Preview the created image and download using the button below",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -32,6 +32,7 @@
   "GeoMetWms": "Ajouter des couches {wmsSource}",
   "GoToHomePage": "Aller à la page d'accueil AniMet du SMC",
   "Grey": "Grise",
+  "InvalidSRS": "Le SRC {CRS} n'est pas valide pour cette source de données.",
   "JPEGCreateButtonLabel": "Créer l'image",
   "JPEGExportDownload": "Télécharger au format JPEG",
   "JPEGExportSubtitle": "Prévisualiser l'image créée et télécharger à l'aide du bouton ci-dessous",

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -92,7 +92,7 @@ export default {
       } else {
         return
       }
-      this.emitter.emit('collapseMenu')
+      this.emitter.emit('collapseMenu', true)
       let layer = {}
       layer.Name = layerName
       layer.isLeaf = true


### PR DESCRIPTION
- Removed some unused CSS classes;
- Added proper handling for attempts of adding layers on a unsupported CRS;
- Fixed tabs automatically changing to configurations tab seemingly randomly and sometimes staying on configurations tab even though the layers list was empty.