### PR TITLE
Added NRCan as a source for Nightly since the overlays tab was removed

### DIFF
--- a/scripts/generate_trees_layers_list.py
+++ b/scripts/generate_trees_layers_list.py
@@ -201,10 +201,14 @@ for name, params in wms_sources.items():
         sources_to_remove.append(name)
         continue
     for lang in langs:
-        if "?" in params["url"]:
-            base_url = f"{params['url']}&lang={lang}"
+        if f"url_{lang}" in params:
+            base_url = params[f"url_{lang}"]
         else:
-            base_url = f"{params['url']}?lang={lang}"
+            base_url = params["url"]
+        if "?" in base_url:
+            base_url = f"{base_url}&lang={lang}"
+        else:
+            base_url = f"{base_url}?lang={lang}"
         try:
             wms = WebMapService(base_url, version=params["version"])
         except Exception as e:

--- a/scripts/wms_sources_configs.py
+++ b/scripts/wms_sources_configs.py
@@ -54,4 +54,10 @@ wms_sources = {
         "no_translations": True,
         "display": os.environ.get("ANIMET_NIGHTLY", default=False),
     },
+    "NRCan": {
+        "url": "https://maps.geogratis.gc.ca/wms/canvec_en",
+        "url_fr": "https://maps.geogratis.gc.ca/wms/canvec_fr",
+        "version": "1.3.0",
+        "display": os.environ.get("ANIMET_NIGHTLY", default=False),
+    },
 }

--- a/src/components/Layers/LayerTree.vue
+++ b/src/components/Layers/LayerTree.vue
@@ -33,7 +33,7 @@
               @click:clear="filterOnInput(this.tab)"
             >
             </v-text-field>
-            <div :ref="wmsSource" class="treeview pr-0">
+            <div class="treeview pr-0">
               <tree-node
                 v-for="node in filteredTreeNodes[this.tab]"
                 :key="`${node.Name}`"
@@ -341,7 +341,7 @@ export default {
     },
     resetSearchAndTree() {
       this.searchGeoMet.fill(null)
-      for (let i = 0; i < Object.keys(this.$refs).length; i++) {
+      for (let i = 0; i < Object.keys(this.filteredTreeNodes).length; i++) {
         this.filterOnInput(i)
       }
     },

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -78,6 +78,7 @@
   "NotFound": "404 Not Found",
   "NotFoundSub": "The page you are looking for does not exist.",
   "NoTimeTooltip": "Layer has no temporal dimension",
+  "NRCan": "Natural Resources Canada",
   "OtherProperties": "Properties",
   "OutputFormat": "Output format",
   "Portrait": "Portrait",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -78,6 +78,7 @@
   "NotFound": "Erreur 404",
   "NotFoundSub": "La page que vous recherchez est introuvable.",
   "NoTimeTooltip": "La couche ne possède pas de dimension temporelle",
+  "NRCan": "Ressources naturelles Canada",
   "OtherProperties": "Propriétés",
   "OutputFormat": "Format de sortie",
   "Portrait": "Portrait",


### PR DESCRIPTION
Small changes to allow NRCan as a WMS source on Nightly.
Fixed small bug where $refs reset wasn't resetting anything when more than 2 trees existed.