### PR TITLE
Fixed textbox and added vector arrow

### DIFF
--- a/src/components/Animation/AnimationCanvas.vue
+++ b/src/components/Animation/AnimationCanvas.vue
@@ -15,6 +15,8 @@ import OSM from 'ol/source/OSM'
 import Stroke from 'ol/style/Stroke.js'
 import TileLayer from 'ol/layer/Tile'
 import View from 'ol/View'
+import { Vector as VectorLayer } from 'ol/layer.js'
+import { Vector as VectorSource } from 'ol/source.js'
 
 import 'ol/ol.css'
 
@@ -211,6 +213,24 @@ export default {
           })
           this.copiedLayers.push(newLayer)
           this.$animationCanvas.mapObj.addLayer(newLayer)
+        }
+      })
+      this.$mapCanvas.mapObj.getLayers().forEach((layer) => {
+        if (layer instanceof VectorLayer) {
+          const newSource = new VectorSource({
+            features: layer
+              .getSource()
+              .getFeatures()
+              .map((feature) => feature.clone()),
+          })
+          const vector = new VectorLayer({
+            source: newSource,
+            style: layer.getStyle(),
+            zIndex: layer.getZIndex(),
+            visible: layer.getVisible(),
+          })
+
+          this.$animationCanvas.mapObj.addLayer(vector)
         }
       })
     },

--- a/src/components/Map/EditableTextBox.vue
+++ b/src/components/Map/EditableTextBox.vue
@@ -1,27 +1,26 @@
 <template>
-  <div class="textbox-wrapper">
-    <DraggableResizable
-      :initialPosition="initialPosStyle()"
-      resizeDirection="both"
-      @checkIntersect="checkIntersect"
-    >
-      <div class="text-box-container">
-        <div
-          :id="`text-box-${id}`"
-          class="text-box"
-          contentEditable="plaintext-only"
-          spellcheck="false"
-          @blur="handleUnfocus"
-          @focus="onTextboxFocus"
-          @keydown.left.right.space.enter.stop
-        ></div>
-        <button
-          class="close-button mdi mdi-close"
-          @click="destroyTextbox"
-        ></button>
-      </div>
-    </DraggableResizable>
-  </div>
+  <DraggableResizable
+    :initialPosition="initialPosStyle()"
+    resizeDirection="both"
+    @checkIntersect="checkIntersect"
+  >
+    <div class="text-box-container">
+      <div
+        :id="`text-box-${id}`"
+        class="text-box"
+        contentEditable="true"
+        spellcheck="false"
+        @blur="handleUnfocus"
+        @focus="onTextboxFocus"
+        @paste="handlePaste"
+        @keydown.left.right.space.enter.stop
+      ></div>
+      <button
+        class="close-button mdi mdi-close"
+        @click="destroyTextbox"
+      ></button>
+    </div>
+  </DraggableResizable>
 </template>
 
 <script setup>
@@ -59,6 +58,17 @@ const onTextboxFocus = () => {
 
 const handleUnfocus = () => {
   store.setTextBoxFocused(false)
+}
+
+const handlePaste = (evt) => {
+  evt.preventDefault()
+  const text = evt.clipboardData?.getData('text/plain')
+  const selectedRange = window.getSelection()?.getRangeAt(0)
+  if (!selectedRange || !text) return
+
+  selectedRange.deleteContents()
+  selectedRange.insertNode(document.createTextNode(text))
+  selectedRange.setStart(selectedRange.endContainer, selectedRange.endOffset)
 }
 
 const initialPosStyle = () => {
@@ -109,6 +119,16 @@ const checkIntersect = () => {
   opacity: 0;
   content: 'placeholder';
 }
+@media (pointer: coarse) {
+  .text-box-container:focus-within .close-button {
+    display: block;
+  }
+}
+@media (hover: hover) {
+  .text-box-container:hover .close-button {
+    display: block;
+  }
+}
 .close-button {
   position: absolute;
   top: 0;
@@ -124,9 +144,6 @@ const checkIntersect = () => {
   cursor: pointer;
   display: none;
   transition: background-color 0.3s;
-}
-.text-box-container:hover .close-button {
-  display: block;
 }
 .close-button:hover {
   background-color: rgba(255, 0, 0, 0.7);

--- a/src/components/Map/LegendControls.vue
+++ b/src/components/Map/LegendControls.vue
@@ -8,16 +8,22 @@
     @dblclick="emitter.emit('openPanel')"
     @click="emit('legend-click', name)"
   >
-    <img
-      class="white"
-      :class="getLegendHidden"
-      :id="name"
-      :name="name"
-      :src="getMapLegendURL"
-      :style="{ border: getStyle }"
-      :title="name"
-      crossorigin="anonymous"
-    />
+    <div class="image-container">
+      <img
+        class="white"
+        :class="getLegendHidden"
+        :id="name"
+        :name="name"
+        :src="getMapLegendURL"
+        :style="{ border: getStyle }"
+        :title="name"
+        crossorigin="anonymous"
+      />
+      <button
+        class="close-button mdi mdi-close"
+        @pointerup="emit('legend-remove', name)"
+      ></button>
+    </div>
   </DraggableResizable>
 </template>
 
@@ -29,7 +35,7 @@ import { useI18n } from 'vue-i18n'
 const { proxy } = getCurrentInstance()
 
 const props = defineProps(['name'])
-const emit = defineEmits(['legend-click'])
+const emit = defineEmits(['legend-click', 'legend-remove'])
 
 const store = inject('store')
 const { locale } = useI18n()
@@ -139,5 +145,34 @@ onBeforeUnmount(() => {
   height: auto;
   object-fit: contain;
   vertical-align: middle;
+}
+@media (pointer: coarse) {
+  .image-container .close-button {
+    display: block;
+  }
+}
+@media (hover: hover) {
+  .image-container:hover .close-button {
+    display: block;
+  }
+}
+.close-button {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 16px;
+  height: 16px;
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+  display: none;
+  transition: background-color 0.3s;
+}
+.close-button:hover {
+  background-color: rgba(255, 0, 0, 0.7);
 }
 </style>

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1,4 +1,6 @@
 {
+  "AddArrow": "Arrow",
+  "AddTextbox": "Textbox",
   "AnimationFrom": "Weather animation from",
   "AppBarCreate": "Animation configuration",
   "AppBarExport": "Created animation",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -1,4 +1,6 @@
 {
+  "AddArrow": "Flèche",
+  "AddTextbox": "Boite de texte",
   "AnimationFrom": "Animation météo de",
   "AppBarCreate": "Configuration",
   "AppBarExport": "Animation créée",


### PR DESCRIPTION
- Added Vector arrows than can be translated and rotated;
- Arrows also appear in the animation;
- Fixed textbox so it would work in Firefox;
- Textboxes can now be deleted on tablets;
- Legends now have an X button on the top right on hover OR always visible for touch screens;
- Legends now don't "remember" the last legend that was clicked and if you click away from a legend it will no longer be selected (so that pressing delete after clicking elsewhere won't affect the last clicked legend);
- Context menu now translates on language change;
- Vector arrows can be deleted when selected and clicking the delete key OR on touch devices selecting the arrow and then holding on it for 1.5sec will slowly reduce opacity until it is removed entirely;
- GFI will not open if you click on a vector feature;
- GFI will not open on phone when trying to open the contextMenu (because right click on touch devices doesn't exist and you simply hold press to open right click menu, which would normally trigger a GFI).