### PR TITLE
ECMWF added as a nightly source

### DIFF
--- a/scripts/wms_sources_configs.py
+++ b/scripts/wms_sources_configs.py
@@ -27,6 +27,12 @@ wms_sources = {
         "no_translations": True,
         "display": os.environ.get("ANIMET_NIGHTLY", default=False),
     },
+    "ECMWF": {
+        "url": "https://eccharts.ecmwf.int/wms/?token=public",
+        "version": "1.3.0",
+        "no_translations": True,
+        "display": os.environ.get("ANIMET_NIGHTLY", default=False),
+    },
     "NASA": {
         "url": "https://gibs.earthdata.nasa.gov/wms/epsg3857/best/wms.cgi",
         "version": "1.3.0",

--- a/src/mixins/datetimeManipulations.js
+++ b/src/mixins/datetimeManipulations.js
@@ -213,6 +213,16 @@ export default {
           }
           return [dateArrays, trueIntervals, intervals]
         }
+        case /^[^,/]+,[^,/]+\/[^,/]+\/[^,/]+/.test(dateRange): {
+          let [singleDate, firstInterval, ...remainingIntervals] =
+            dateRange.split(',')
+          let [_, endDate, duration] = firstInterval.split('/')
+          firstInterval = `${singleDate}/${endDate}/${duration}`
+          dateRange = remainingIntervals.length
+            ? `${firstInterval},${remainingIntervals.join(',')}`
+            : firstInterval
+          return this.findFormat(dateRange)
+        }
         default:
           return [null, null, null]
       }


### PR DESCRIPTION
- Needed to add a regex case to merge the first date and interval in the ECMWF WMS, i.e.:
`2025-01-29T12:00:00Z,2025-01-29T15:00:00Z/2025-02-09T00:00:00Z/PT3H`
needed to become
`2025-01-29T12:00:00Z/2025-02-09T00:00:00Z/PT3H`
