### PR TITLE
Fixed GFI having empty properties when it only contained Value prop

### DIFF
--- a/src/components/Map/GetFeatureInfo.vue
+++ b/src/components/Map/GetFeatureInfo.vue
@@ -292,18 +292,20 @@ export default {
                       delete json.features[0].properties.value
                       index++
                     }
-                    feature.push({
-                      id: index,
-                      name: this.t('OtherProperties'),
-                      children: Object.entries(json.features[0].properties).map(
-                        ([key, value], childIndex) => {
+                    if (Object.keys(json.features[0].properties).length > 0) {
+                      feature.push({
+                        id: index,
+                        name: this.t('OtherProperties'),
+                        children: Object.entries(
+                          json.features[0].properties,
+                        ).map(([key, value], childIndex) => {
                           return {
                             id: `${index}-${childIndex}`,
                             name: `${key}: ${value}`,
                           }
-                        },
-                      ),
-                    })
+                        }),
+                      })
+                    }
                     index++
 
                     const item = {


### PR DESCRIPTION
Since we pop the "value" property out of "properties" in the GFI, there was a bug for climate where you'd see a dropdown for properties that would disappear as soon as you clicked on it because it no longer contained anything. Just added a small check to not add properties in case it's empty.