### PR TITLE
Fixed Node changing its name with the source in the layer tree

### DIFF
--- a/src/components/Layers/LayerTree.vue
+++ b/src/components/Layers/LayerTree.vue
@@ -60,7 +60,8 @@
                       {{
                         $mapLayers.arr.some(
                           (l) =>
-                            l.get('layerName') === node.Name &&
+                            l.get('layerName').split(' ')[0] ===
+                              node.Name.split(' ')[0] &&
                             Object.values(wmsSources)[l.get('layerWmsIndex')][
                               'url'
                             ] === currentWmsSource,
@@ -90,7 +91,8 @@
                           'title-leaf': node.isLeaf,
                           'text-primary': $mapLayers.arr.some(
                             (l) =>
-                              l.get('layerName') === node.Name &&
+                              l.get('layerName').split(' ')[0] ===
+                                node.Name.split(' ')[0] &&
                               Object.values(wmsSources)[l.get('layerWmsIndex')][
                                 'url'
                               ] === currentWmsSource,
@@ -104,7 +106,9 @@
                         }}
                         <template v-if="node.isLeaf">
                           <br />
-                          <span class="subtitle">{{ node.Name }}</span>
+                          <span class="subtitle">{{
+                            node.Name.split(' ')[0]
+                          }}</span>
                         </template>
                       </span>
                     </template>


### PR DESCRIPTION
Fixed layer tree Node adding the source tag in the layer tree, making it unaware of layers added from specific sources after coming from a permalink:
![image](https://github.com/user-attachments/assets/1af03890-eefc-47f6-b99a-8752c3bfc9b2)
