### PR TITLE
Actually found the dark bug

### DIFF
--- a/src/components/GlobalConfigs/PageTheme.vue
+++ b/src/components/GlobalConfigs/PageTheme.vue
@@ -50,7 +50,10 @@ export default {
     }
 
     const userThemeChoice = getTheme()
-    if (!userThemeChoice) {
+    if (
+      !userThemeChoice ||
+      (userThemeChoice !== 'light' && userThemeChoice !== 'dark')
+    ) {
       theme.global.name.value = getMediaPreference()
       localStorage.setItem('user-theme', theme.global.name.value)
     } else {


### PR DESCRIPTION
AniMet before used localStorage values for light/dark theme of `true/false`

Now it’s `light/dark`

But my check was looking at “if there’s no value for theme, set it, otherwise take the one that’s there”, which was setting the theme to, for example, `true` instead of `light`.

This is also why the bug stopped appearing as soon as you clicked on the theme button a single time and whatever you did you couldn't reproduce afterwards, it's because it was an artifact from the previous version's local storage which, after clicking once, no longer exists.