### PR TITLE
Fix for space and accents in variable names...

### DIFF
--- a/src/components/Animation/AnimationConfiguration.vue
+++ b/src/components/Animation/AnimationConfiguration.vue
@@ -261,7 +261,7 @@ export default {
               layer.get('layerTimeStep') === this.mapTimeSettings.Step
             ) {
               this.store.setAnimationTitle(
-                this.t(layer.get('layerName').split(' ')[0]),
+                this.t(layer.get('layerName').split('/')[0]),
               )
               break
             }

--- a/src/components/Animation/AnimationRectangle.vue
+++ b/src/components/Animation/AnimationRectangle.vue
@@ -87,7 +87,7 @@ export default {
         let isLayerListShown = !(
           visibleLayers.length === 1 &&
           this.animationTitle ===
-            this.t(visibleLayers[0].get('layerName').split(' ')[0])
+            this.t(visibleLayers[0].get('layerName').split('/')[0])
         )
         // Must be divisible by 2 otherwise encoder.initialize() will fail
         let ctx_h = 40
@@ -106,7 +106,7 @@ export default {
         if (isLayerListShown) {
           ctx_h = 0
           for (let i = visibleLayers.length - 1; i >= 0; i--) {
-            let layerTitle = `• ${this.t(visibleLayers[i].get('layerName').split(' ')[0])}`
+            let layerTitle = `• ${this.t(visibleLayers[i].get('layerName').split('/')[0])}`
             let fontSize = baseFont
             ctx.font = fontSize + 'px sans-serif'
             metrics = ctx.measureText(layerTitle)

--- a/src/components/Animation/CreateAnimation.vue
+++ b/src/components/Animation/CreateAnimation.vue
@@ -745,7 +745,7 @@ export default {
       let ctx_w = this.mapWidth
       this.isLayerListShown = !(
         visibleLayers.length === 1 &&
-        customTitle === this.t(visibleLayers[0].get('layerName').split(' ')[0])
+        customTitle === this.t(visibleLayers[0].get('layerName').split('/')[0])
       )
       // Must be divisible by 2 otherwise encoder.initialize() will fail
       let ctx_h = 40
@@ -765,7 +765,7 @@ export default {
       if (this.isLayerListShown) {
         ctx_h = 0
         for (let i = visibleLayers.length - 1; i >= 0; i--) {
-          let layerTitle = `• ${this.t(visibleLayers[i].get('layerName').split(' ')[0])}`
+          let layerTitle = `• ${this.t(visibleLayers[i].get('layerName').split('/')[0])}`
           let fontSize = baseFont
           ctx.font = fontSize + 'px sans-serif'
           metrics = ctx.measureText(layerTitle)

--- a/src/components/GlobalConfigs/Share/PermaLink.vue
+++ b/src/components/GlobalConfigs/Share/PermaLink.vue
@@ -157,7 +157,7 @@ export default {
               ? '1'
               : '0'
 
-            const [name, source] = layerName.split(' ')
+            const [name, source] = layerName.split('/')
             const layerParams = [
               name,
               layerOpacity,

--- a/src/components/Layers/LayerConfiguration.vue
+++ b/src/components/Layers/LayerConfiguration.vue
@@ -18,8 +18,8 @@
             v-if="isAnimating && !configPanelHover && playState === 'play'"
             class="pa-0"
           >
-            <v-list-item-title :title="$t(item.get('layerName').split(' ')[0])">
-              {{ $t(item.get('layerName').split(' ')[0]) }}
+            <v-list-item-title :title="$t(item.get('layerName').split('/')[0])">
+              {{ $t(item.get('layerName').split('/')[0]) }}
             </v-list-item-title>
             <v-list-item-subtitle class="layer-subtitle">
               {{ item.get('layerName') }}
@@ -38,9 +38,9 @@
           <template v-else class="pa-0">
             <v-col class="pa-0">
               <v-list-item-title
-                :title="$t(item.get('layerName').split(' ')[0])"
+                :title="$t(item.get('layerName').split('/')[0])"
               >
-                {{ $t(item.get('layerName').split(' ')[0]) }}
+                {{ $t(item.get('layerName').split('/')[0]) }}
               </v-list-item-title>
               <v-list-item-subtitle class="layer-subtitle">
                 {{ item.get('layerName') }}

--- a/src/components/Layers/LayerTree.vue
+++ b/src/components/Layers/LayerTree.vue
@@ -60,8 +60,8 @@
                       {{
                         $mapLayers.arr.some(
                           (l) =>
-                            l.get('layerName').split(' ')[0] ===
-                              node.Name.split(' ')[0] &&
+                            l.get('layerName').split('/')[0] ===
+                              node.Name.split('/')[0] &&
                             Object.values(wmsSources)[l.get('layerWmsIndex')][
                               'url'
                             ] === currentWmsSource,
@@ -91,8 +91,8 @@
                           'title-leaf': node.isLeaf,
                           'text-primary': $mapLayers.arr.some(
                             (l) =>
-                              l.get('layerName').split(' ')[0] ===
-                                node.Name.split(' ')[0] &&
+                              l.get('layerName').split('/')[0] ===
+                                node.Name.split('/')[0] &&
                               Object.values(wmsSources)[l.get('layerWmsIndex')][
                                 'url'
                               ] === currentWmsSource,
@@ -107,7 +107,7 @@
                         <template v-if="node.isLeaf">
                           <br />
                           <span class="subtitle">{{
-                            node.Name.split(' ')[0]
+                            node.Name.split('/')[0]
                           }}</span>
                         </template>
                       </span>
@@ -187,7 +187,7 @@ export default {
         this.emitter.emit('toggleAnimation')
       }
       if (layer.isLeaf) {
-        layer.Name = layer.Name.split(' ')[0]
+        layer.Name = layer.Name.split('/')[0]
         let source = Object.hasOwn(layer, 'wmsSource')
           ? layer.wmsSource
           : this.currentWmsSource
@@ -197,7 +197,7 @@ export default {
         )
         const sourceValues = this.wmsSources[sources[layer.wmsIndex]]
         if (sourceValues['source_validation']) {
-          layer.Name = `${layer.Name} ${sources[layer.wmsIndex]}`
+          layer.Name = `${layer.Name}/${sources[layer.wmsIndex]}`
         }
         if (!this.addedLayers.includes(layer.Name)) {
           if (Object.hasOwn(sourceValues, 'query_pattern')) {
@@ -221,7 +221,7 @@ export default {
                 SERVICE: 'WMS',
                 VERSION: '1.3.0',
                 REQUEST: 'GetCapabilities',
-                LAYERS: layer.Name.split(' ')[0],
+                LAYERS: layer.Name.split('/')[0],
                 t: new Date().getTime(),
               },
             })
@@ -230,7 +230,7 @@ export default {
                 response.data,
                 'text/xml',
               )
-              const layerName = layer.xmlName.split(' ')[0]
+              const layerName = layer.xmlName.split('/')[0]
               const xpathExpression = `//wms:Layer[not(.//wms:Layer) and wms:Name='${layerName}']`
               function nsResolver(prefix) {
                 const ns = {

--- a/src/components/Map/GetFeatureInfo.vue
+++ b/src/components/Map/GetFeatureInfo.vue
@@ -202,7 +202,9 @@ export default {
         if (item.children[0].name.includes(':')) {
           const value = item.children[0].name.split(':')[1]
           item.children[0].name = `${this.t('Value')}${this.t('Colon')}${value}`
-          item.children[1].name = this.t('OtherProperties')
+          if (item.children[1]) {
+            item.children[1].name = this.t('OtherProperties')
+          }
         } else {
           item.children[0].name = this.t('OtherProperties')
         }

--- a/src/components/Map/MapCanvas.vue
+++ b/src/components/Map/MapCanvas.vue
@@ -368,7 +368,7 @@ export default {
         source: new ImageWMS({
           format: 'image/png',
           url: wmsSource,
-          params: { LAYERS: layerData.Name.split(' ')[0] },
+          params: { LAYERS: layerData.Name.split('/')[0] },
           transition: 0,
           crossOrigin: 'Anonymous',
           ratio: 1,

--- a/src/components/Time/AutoRefresh.vue
+++ b/src/components/Time/AutoRefresh.vue
@@ -65,7 +65,7 @@ export default {
                 SERVICE: 'WMS',
                 VERSION: '1.3.0',
                 REQUEST: 'GetCapabilities',
-                LAYERS: layerName.split(' ')[0],
+                LAYERS: layerName.split('/')[0],
                 t: new Date().getTime(),
               },
             })
@@ -74,7 +74,7 @@ export default {
                 response.data,
                 'text/xml',
               )
-              const layerName = layer.get('layerXmlName').split(' ')[0]
+              const layerName = layer.get('layerXmlName').split('/')[0]
               const xpathExpression = `//wms:Layer[not(.//wms:Layer) and wms:Name='${layerName}']`
               function nsResolver(prefix) {
                 const ns = {

--- a/src/components/Time/ErrorManager.vue
+++ b/src/components/Time/ErrorManager.vue
@@ -364,7 +364,7 @@ export default {
             SERVICE: 'WMS',
             VERSION: '1.3.0',
             REQUEST: 'GetCapabilities',
-            LAYERS: layer.get('layerName').split(' ')[0],
+            LAYERS: layer.get('layerName').split('/')[0],
             t: new Date().getTime(),
           },
         })
@@ -373,7 +373,7 @@ export default {
             response.data,
             'text/xml',
           )
-          const layerName = layer.get('layerXmlName').split(' ')[0]
+          const layerName = layer.get('layerXmlName').split('/')[0]
           const xpathExpression = `//wms:Layer[not(.//wms:Layer) and wms:Name='${layerName}']`
           function nsResolver(prefix) {
             const ns = {

--- a/src/utils/AxiosConfig.js
+++ b/src/utils/AxiosConfig.js
@@ -1,8 +1,6 @@
 import axios from 'axios'
 import axiosRetry from 'axios-retry'
 
-axios.defaults.withCredentials = true
-
 axiosRetry(axios, {
   retries: 4,
   retryDelay: (retryCount) => retryCount * 800,


### PR DESCRIPTION
- Changed spaces for "/" for the delimitation parameter for sources with same layer names so that sources containing layernames with special characters and spaces don't break...
- Also small fix for GFI with climate layers when opened+changing language.