### PR TITLE
Added extrapolation to presets, reduced play delay to 250ms, text disabled when layer is OOB

### DIFF
--- a/src/assets/presets/presets.js
+++ b/src/assets/presets/presets.js
@@ -92,6 +92,13 @@ export default {
               legendDisplayed: false,
             },
             {
+              Title: 'Radar extrapolation precipitation rate for rain [mm/h]',
+              Name: 'Radar_1km_RainPrecipRate-Extrapolation',
+              isLeaf: true,
+              isTemporal: true,
+              legendDisplayed: false,
+            },
+            {
               Title: 'Radar precipitation rate for rain [mm/h]',
               Name: 'RADAR_1KM_RRAI',
               isLeaf: true,
@@ -131,6 +138,13 @@ export default {
             {
               Title: 'Dynamic radar coverage for snow',
               Name: 'RADAR_COVERAGE_RSNO',
+              isLeaf: true,
+              isTemporal: true,
+              legendDisplayed: false,
+            },
+            {
+              Title: 'Radar extrapolation precipitation rate for snow [cm/h]',
+              Name: 'Radar_1km_SnowPrecipRate-Extrapolation',
               isLeaf: true,
               isTemporal: true,
               legendDisplayed: false,

--- a/src/components/Layers/LayerConfiguration.vue
+++ b/src/components/Layers/LayerConfiguration.vue
@@ -12,6 +12,8 @@
               !isAnimating || configPanelHover || playState !== 'play',
             'pr-3': numLayers === 1,
             'pr-0': numLayers !== 0,
+            'text-disabled':
+              item.get('layerDateIndex') < 0 || !item.get('layerVisibilityOn'),
           }"
         >
           <template

--- a/src/components/Time/AnimationControls/PlayPauseControls.vue
+++ b/src/components/Time/AnimationControls/PlayPauseControls.vue
@@ -186,8 +186,8 @@ export default {
           )
         }
         if (!this.pendingErrorResolution && this.playState === 'play') {
-          if (r < 1000) {
-            await this.delay(1000 - r)
+          if (r < 250) {
+            await this.delay(250 - r)
           }
           this.playLocked = false
           this.play()


### PR DESCRIPTION
- Extrapolation layers added to radar Snow and radar Rain presets;
- Layers that are not showed because they are out of bounds will also be greyed out in the config panel;
- Reduced minimum time between time jumps from 1 sec to 250ms when playing.