### PR TITLE
Added first/current/last/step range param in permalink

### DIFF
--- a/src/assets/presets/presets.js
+++ b/src/assets/presets/presets.js
@@ -83,6 +83,7 @@ export default {
               isLeaf: true,
               isTemporal: true,
               legendDisplayed: false,
+              opacity: 0.9,
             },
             {
               Title: 'Dynamic radar coverage for rain',
@@ -90,6 +91,7 @@ export default {
               isLeaf: true,
               isTemporal: true,
               legendDisplayed: false,
+              opacity: 0.9,
             },
             {
               Title: 'Radar extrapolation precipitation rate for rain [mm/h]',
@@ -97,12 +99,14 @@ export default {
               isLeaf: true,
               isTemporal: true,
               legendDisplayed: false,
+              opacity: 0.9,
             },
             {
               Title: 'Radar precipitation rate for rain [mm/h]',
               Name: 'RADAR_1KM_RRAI',
               isLeaf: true,
               isTemporal: true,
+              opacity: 0.9,
             },
           ],
         },
@@ -134,6 +138,7 @@ export default {
               isLeaf: true,
               isTemporal: true,
               legendDisplayed: false,
+              opacity: 0.9,
             },
             {
               Title: 'Dynamic radar coverage for snow',
@@ -141,6 +146,7 @@ export default {
               isLeaf: true,
               isTemporal: true,
               legendDisplayed: false,
+              opacity: 0.9,
             },
             {
               Title: 'Radar extrapolation precipitation rate for snow [cm/h]',
@@ -148,12 +154,14 @@ export default {
               isLeaf: true,
               isTemporal: true,
               legendDisplayed: false,
+              opacity: 0.9,
             },
             {
               Title: 'Radar precipitation rate for snow [cm/h]',
               Name: 'RADAR_1KM_RSNO',
               isLeaf: true,
               isTemporal: true,
+              opacity: 0.9,
             },
           ],
         },

--- a/src/components/GlobalConfigs/Share/PermaLink.vue
+++ b/src/components/GlobalConfigs/Share/PermaLink.vue
@@ -91,6 +91,9 @@ export default {
     currentCRS() {
       return this.store.getCurrentCRS
     },
+    datetimeRangeSlider() {
+      return this.store.getDatetimeRangeSlider
+    },
     extent() {
       return this.store.getExtent
     },
@@ -218,6 +221,10 @@ export default {
 
         if (this.playState === 'play') {
           permalinktemp += `&play=1`
+        }
+
+        if (this.mapTimeSettings.Step) {
+          permalinktemp += `&range=${this.datetimeRangeSlider[0]},${this.mapTimeSettings.DateIndex},${this.datetimeRangeSlider[1]},${this.mapTimeSettings.Step}`
         }
 
         this.router.replace({

--- a/src/components/Layers/LayerTree.vue
+++ b/src/components/Layers/LayerTree.vue
@@ -182,7 +182,7 @@ export default {
       this.addedLayers = this.addedLayers.filter((added) => added !== layerName)
     },
     async requestLayerData(eventData) {
-      const { layer, autoPlay = false } = eventData
+      const { layer, autoPlay = false, range = undefined } = eventData
       if (this.playState === 'play') {
         this.emitter.emit('toggleAnimation')
       }
@@ -292,7 +292,12 @@ export default {
             })
             layerData = { ...layerData, ...layer }
             layerData.isTemporal = layerData.Dimension.Dimension_time !== ''
-            this.emitter.emit('buildLayer', { layerData, source, autoPlay })
+            this.emitter.emit('buildLayer', {
+              layerData,
+              source,
+              autoPlay,
+              range,
+            })
           } catch (err) {
             this.removeLayer(layer.Name)
           }

--- a/src/components/Time/AnimationControls/PlayPauseControls.vue
+++ b/src/components/Time/AnimationControls/PlayPauseControls.vue
@@ -186,6 +186,14 @@ export default {
           )
         }
         if (!this.pendingErrorResolution && this.playState === 'play') {
+          if (restore) {
+            r = await this.measurePromise(
+              () =>
+                new Promise((resolve) =>
+                  this.$mapCanvas.mapObj.once('rendercomplete', resolve),
+                ),
+            )
+          }
           if (r < 250) {
             await this.delay(250 - r)
           }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -18,6 +18,7 @@ const routes = [
       proj: route.query.proj,
       grat: route.query.grat,
       play: route.query.play,
+      range: route.query.range,
     }),
   },
   {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -9,6 +9,7 @@
 <script>
 import localeData from '../locales/importLocaleFiles'
 import proj4 from 'proj4'
+import { Duration } from 'luxon'
 import { register } from 'ol/proj/proj4'
 
 export default {
@@ -23,6 +24,7 @@ export default {
     'proj',
     'grat',
     'play',
+    'range',
   ],
   data() {
     return {
@@ -131,11 +133,38 @@ export default {
           return
         }
       }
+      let range
       if (this.layerCount === 0) {
         if (this.play) {
           this.emitter.emit('changeTab')
         } else {
           this.emitter.emit('collapseMenu', true)
+        }
+        if (this.range !== undefined) {
+          let [first, current, last, step] = this.range.split(',')
+          first = Number(first)
+          current = Number(current)
+          last = Number(last)
+          step = step.trim()
+          if (
+            Number.isInteger(first) &&
+            Number.isInteger(current) &&
+            Number.isInteger(last)
+          ) {
+            try {
+              // Attempt Duration.fromISO to make sure the step is valid
+              Duration.fromISO(step)
+              if (!(0 <= first && first <= current && current <= last)) {
+                range = undefined
+              } else {
+                range = [first, current, last, step]
+              }
+            } catch {
+              range = undefined
+            }
+          } else {
+            range = undefined
+          }
         }
       }
       let layer = {}
@@ -154,7 +183,11 @@ export default {
         layer.legendDisplayed = legendDisplayed
       }
       const autoPlay = this.play && this.layerCount === 0
-      this.emitter.emit('permaLinkLayer', { layer, autoPlay })
+      this.emitter.emit('permaLinkLayer', {
+        layer,
+        autoPlay,
+        range,
+      })
     },
     findKeyInLocaleFiles(key) {
       for (const sourceName in localeData['enLocaleData']) {


### PR DESCRIPTION
- Added new parameter in the permalink "range" that remembers indices of the time controls and the selected time interval `&range=first,current,last,step`;
- Changed opacity of radar presets layers to 0.9;
- Fixed bug where coming from a permalink with `play=1` could sometimes cause the timesteps to move forward without waiting for the layers to be done loading.