### PR TITLE
Update ALERTS opacity for alerts/current conditions preset

### DIFF
--- a/src/assets/presets/presets.js
+++ b/src/assets/presets/presets.js
@@ -291,7 +291,7 @@ export default {
               Name: 'ALERTS',
               isLeaf: true,
               isTemporal: true,
-              opacity: 1,
+              opacity: 0.6,
             },
             {
               Title: 'Current Conditions',


### PR DESCRIPTION
Updates the ALERTS layer opacity to 0.60 for the `Alerts & Current Conditions` preset.