### PR TITLE
Added overlays to localstorage preferences

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -34,6 +34,9 @@ export default {
         this.wmsSources[Object.keys(this.activeSources)[0]]['url'],
       )
     }
+    if (this.getUserSelectedOverlays() === undefined) {
+      localStorage.setItem('user-overlays', JSON.stringify(['Boundaries']))
+    }
   },
   methods: {
     getLang() {
@@ -41,6 +44,9 @@ export default {
     },
     getSources() {
       return localStorage.getItem('user-sources')
+    },
+    getUserSelectedOverlays() {
+      return localStorage.getItem('user-overlays') || undefined
     },
   },
   computed: {

--- a/src/components/GlobalConfigs/MapCustomizations/MapPreviews.vue
+++ b/src/components/GlobalConfigs/MapCustomizations/MapPreviews.vue
@@ -789,6 +789,10 @@ export default {
         }
       })
     },
+    getUserSelectedOverlays() {
+      const stored = localStorage.getItem('user-overlays')
+      return stored ? JSON.parse(stored) : []
+    },
     saveUserBasemapPreference(selections, backgroundColor) {
       let basename
       if (selections.base.includes('NoBasemap')) {
@@ -917,6 +921,21 @@ export default {
             displayCondition,
           )
           this.store.toggleOverlay(color.name)
+          const overlayPreferences = this.getUserSelectedOverlays()
+          const overlayPreferenceIndex = overlayPreferences.indexOf(color.name)
+          if (this.activeOverlays.includes(color.name)) {
+            if (overlayPreferenceIndex === -1) {
+              overlayPreferences.push(color.name)
+            }
+          } else {
+            if (overlayPreferenceIndex !== -1) {
+              overlayPreferences.splice(overlayPreferenceIndex, 1)
+            }
+          }
+          localStorage.setItem(
+            'user-overlays',
+            JSON.stringify(overlayPreferences),
+          )
           this.emitter.emit('updatePermalink')
         } else if (currentBase === `${source}-${color.name}`) {
           this.isUserInitiated = true

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -65,9 +65,10 @@ export default {
     }
   },
   async mounted() {
-    let userBasemap, userColor
+    let userBasemap, userColor, userOverlays
     if (this.allPropsUndefined) {
       ;[userBasemap, userColor] = this.getBase() || []
+      userOverlays = this.getUserSelectedOverlays() || undefined
     }
 
     const basemap = this.basemap || userBasemap
@@ -129,6 +130,10 @@ export default {
           this.store.toggleOverlay(overlay)
         })
       }
+    } else if (userOverlays !== undefined) {
+      userOverlays.forEach((overlay) => {
+        this.store.toggleOverlay(overlay)
+      })
     } else {
       this.store.toggleOverlay('Boundaries')
     }
@@ -242,6 +247,9 @@ export default {
     },
     getCRS() {
       return localStorage.getItem('user-crs')
+    },
+    getUserSelectedOverlays() {
+      return JSON.parse(localStorage.getItem('user-overlays'))
     },
   },
   computed: {


### PR DESCRIPTION
Overlays selection now added as part of the localstorage so they can be added automatically on blank AniMet load once they've been manually set once. Boundaries added by default to preferences since they're now on by default.