### PR TITLE
Model run added in the permalink and small bugfixes

### DIFF
--- a/src/components/GlobalConfigs/Share/PermaLink.vue
+++ b/src/components/GlobalConfigs/Share/PermaLink.vue
@@ -169,10 +169,23 @@ export default {
                 layerStyle,
                 legendDisplayed,
               ]
-              if (source) {
-                layerParams.push(source)
+
+              const currentMR = layer.get('layerCurrentMR')
+              if (
+                currentMR &&
+                currentMR !==
+                  layer.get('layerModelRuns')[
+                    layer.get('layerModelRuns').length - 1
+                  ]
+              ) {
+                layerParams.push(currentMR.getTime().toString())
               }
+
               permalinktemp += layerParams.join(';')
+
+              if (source) {
+                permalinktemp += `:${source}`
+              }
 
               if (i < this.$mapLayers.arr.length - 1) {
                 permalinktemp += ','

--- a/src/components/Layers/ModelRunHandler.vue
+++ b/src/components/Layers/ModelRunHandler.vue
@@ -46,10 +46,10 @@ export default {
         )
 
       if (
-        newModelRun ===
-        this.item.get('layerModelRuns')[
-          this.item.get('layerModelRuns').length - 1
-        ]
+        newModelRun.getTime() ===
+        this.item
+          .get('layerModelRuns')
+          [this.item.get('layerModelRuns').length - 1].getTime()
       ) {
         this.item.getSource().updateParams({
           DIM_REFERENCE_TIME: undefined,
@@ -63,11 +63,15 @@ export default {
         })
       }
 
+      let layerDefaultTime = this.item.get('layerDefaultTime')
+      if (layerDefaultTime > newDateArray[newDateArray.length - 1]) {
+        layerDefaultTime = newDateArray[newDateArray.length - 1]
+      } else if (layerDefaultTime < newDateArray[0]) {
+        layerDefaultTime = newDateArray[0]
+      }
       this.item.setProperties({
         layerDateArray: newDateArray,
-        layerDefaultTime: new Date(
-          this.item.get('layerDefaultTime').getTime() + timeDiff,
-        ),
+        layerDefaultTime: layerDefaultTime,
         layerCurrentMR: newModelRun,
         layerStartTime: newDateArray[0],
         layerEndTime: newDateArray[newDateArray.length - 1],

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -78,8 +78,30 @@ export default {
       const layersPassed = this.layers.split(',')
       this.layerCount = layersPassed.length
       layersPassed.forEach((layer, index) => {
+        const layerParams = layer.split(';')
+        const [lastValue, sourceSpecified] = layerParams.pop().split(':')
+        const [
+          layerName,
+          opacity,
+          isSnapped,
+          isVisible,
+          style,
+          legendDisplayed,
+          modelRun,
+        ] = [...layerParams, lastValue]
+
         this.layerCount--
-        this.addLayerEvent(index, ...layer.split(';'))
+
+        const params = {
+          layerName,
+          opacity,
+          isSnapped,
+          isVisible,
+          style,
+          legendDisplayed,
+          modelRun,
+        }
+        this.addLayerEvent({ index, ...params, source: sourceSpecified })
       })
     }
     if (this.extent !== undefined) {
@@ -151,7 +173,7 @@ export default {
     }
   },
   methods: {
-    async addLayerEvent(
+    async addLayerEvent({
       index,
       layerName,
       opacity,
@@ -159,8 +181,9 @@ export default {
       isVisible,
       style,
       legendDisplayed,
+      modelRun,
       source,
-    ) {
+    } = {}) {
       let baseURL
       if (source) {
         if (Object.keys(this.wmsSources).includes(source)) {
@@ -255,6 +278,9 @@ export default {
       }
       if (legendDisplayed !== undefined) {
         layer.legendDisplayed = legendDisplayed
+      }
+      if (modelRun !== undefined) {
+        layer.currentMR = modelRun
       }
       const autoPlay = this.play && this.layerCount === 0
       this.emitter.emit('permaLinkLayer', {


### PR DESCRIPTION
- Added model run inside the permalink;
  - Model run is only added if it isn't the latest one;
  - The model run representation is an additional parameter at the end as a timestamp;
  - Changed permalink layer source to be always the last parameter separated by a `:`, making it easier to differentiate between MR and Source since both parameters are optional;
  - Exact model run is remembered, so if it no longer exists it goes back to default latest.
- Fixed `const` variable that would get modified and put `let` instead (only happened when all timesteps where broken);
- Changed modelRunHandler `===` comparison between dates to instead compare them as timestamps;
  - The only reason this worked is because the model run was actually comparing the same object from the list with the objects in the list, it wasn't actually comparing time values. Changed it just in case since it seemed finicky.
- Layer's default time no longer changed according to model run, now it only changes if its default time is lower/higher than the time range's min/max.