### PR TITLE
Small formatting fixes for smaller displays/4-displays

### DIFF
--- a/src/components/Layers/LayerTree.vue
+++ b/src/components/Layers/LayerTree.vue
@@ -483,4 +483,11 @@ export default {
     max-height: calc(100dvh - (34px + 0.5em * 2) - 158px - 190px - 42px - 10px);
   }
 }
+@media (max-height: 565px) {
+  .treeview {
+    max-height: calc(
+      100dvh - (34px + 0.5em * 2) - 190px - 42px - 10px
+    ) !important;
+  }
+}
 </style>

--- a/src/components/Map/LegendControls.vue
+++ b/src/components/Map/LegendControls.vue
@@ -51,11 +51,16 @@ const checkResize = (event) => {
   const isMobile = window.innerWidth <= 768
 
   let maxWidth = isMobile ? window.innerWidth * 0.25 : window.innerWidth * 0.35
+  let maxHeight = window.innerHeight * 0.7
 
-  if (img.naturalWidth > maxWidth) {
-    const container = img.closest('.draggable-container')
-    if (container) {
-      container.style.width = maxWidth + 'px'
+  const container = img.closest('.draggable-container')
+  if (container) {
+    const excessRatio = Math.max(
+      img.naturalWidth / maxWidth,
+      img.naturalHeight / maxHeight,
+    )
+    if (excessRatio > 1) {
+      container.style.width = img.naturalWidth / excessRatio + 'px'
     }
   }
 }


### PR DESCRIPTION
- Legend size automatically decreased based on height compared to screen size as well, no longer just width;
- Side panel now has a bigger minimum size for vertically small displays.