### PR TITLE
CSS to be able to use the menus on very small screens and 4-displays on laptop screens

### DIFF
--- a/src/assets/presets/presets.js
+++ b/src/assets/presets/presets.js
@@ -274,6 +274,7 @@ export default {
               Title: 'GOES-East Natural Color [1 km]',
               Name: 'GOES-East_1km_NaturalColor',
               isLeaf: true,
+              isSnapped: true,
               isTemporal: true,
               opacity: 1,
             },

--- a/src/components/Animation/AnimationConfiguration.vue
+++ b/src/components/Animation/AnimationConfiguration.vue
@@ -251,7 +251,7 @@ export default {
       } else {
         if (this.mapTimeSettings.SnappedLayer !== null) {
           this.store.setAnimationTitle(
-            this.t(this.mapTimeSettings.SnappedLayer),
+            this.t(this.mapTimeSettings.SnappedLayer.split('/')[0]),
           )
         } else if (this.mapTimeSettings.Step !== null) {
           for (let i = this.$mapLayers.arr.length - 1; i >= 0; i--) {
@@ -481,6 +481,19 @@ export default {
     max-height: calc(
       100dvh - (34px + 0.5em * 2) - 0.5em - 158px - 48px - 42px - 10px
     );
+  }
+}
+@media (max-height: 565px) and (max-width: 959px) {
+  .scroll {
+    max-height: calc(
+      100dvh - (34px + 0.5em * 2) - 48px - 42px - 10px
+    ) !important;
+  }
+}
+
+@media (max-height: 565px) and (min-width: 960px) {
+  .scroll {
+    max-height: calc(100dvh - (34px + 0.5em * 2) - 48px - 10px) !important;
   }
 }
 </style>

--- a/src/components/Layers/LayerConfiguration.vue
+++ b/src/components/Layers/LayerConfiguration.vue
@@ -230,4 +230,17 @@ export default {
     );
   }
 }
+@media (max-height: 565px) and (max-width: 959px) {
+  .scroll {
+    max-height: calc(
+      100dvh - (34px + 0.5em * 2) - 48px - 42px - 10px
+    ) !important;
+  }
+}
+
+@media (max-height: 565px) and (min-width: 960px) {
+  .scroll {
+    max-height: calc(100dvh - (34px + 0.5em * 2) - 48px - 10px) !important;
+  }
+}
 </style>

--- a/src/components/Layers/LayerTree.vue
+++ b/src/components/Layers/LayerTree.vue
@@ -483,11 +483,17 @@ export default {
     max-height: calc(100dvh - (34px + 0.5em * 2) - 158px - 190px - 42px - 10px);
   }
 }
-@media (max-height: 565px) {
+@media (max-height: 565px) and (max-width: 959px) {
   .treeview {
     max-height: calc(
-      100dvh - (34px + 0.5em * 2) - 190px - 42px - 10px
+      100dvh - (34px + 0.5em * 2) - 182px - 42px - 10px
     ) !important;
+    min-height: 160px;
+  }
+}
+@media (max-height: 565px) and (min-width: 960px) {
+  .treeview {
+    max-height: calc(100dvh - (34px + 0.5em * 2) - 182px - 10px) !important;
   }
 }
 </style>

--- a/src/components/Map/SidePanel.vue
+++ b/src/components/Map/SidePanel.vue
@@ -286,6 +286,18 @@ export default {
 /* Pre-defined elements */
 .v-container {
   padding: 0;
+  overflow-y: auto;
+}
+@media (max-height: 565px) and (max-width: 959px) {
+  .v-container {
+    max-height: calc(100dvh - (34px + 0.5em * 2) - 42px - 10px) !important;
+  }
+}
+
+@media (max-height: 565px) and (min-width: 960px) {
+  .v-container {
+    max-height: calc(100dvh - (34px + 0.5em * 2) - 10px) !important;
+  }
 }
 .fade-enter-active,
 .fade-leave-active {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -30,6 +30,7 @@ export default {
     return {
       allPropsUndefined: false,
       layerCount: null,
+      layerSnapped: false,
       userCRS: undefined,
     }
   },
@@ -201,6 +202,10 @@ export default {
           return
         }
       }
+      const snapped = isSnapped !== '0' ? true : false
+      if (snapped) {
+        this.layerSnapped = true
+      }
       let range
       if (this.layerCount === 0) {
         if (this.play) {
@@ -208,7 +213,7 @@ export default {
         } else {
           this.emitter.emit('collapseMenu', true)
         }
-        if (this.range !== undefined) {
+        if (this.range !== undefined && !this.layerSnapped) {
           let [first, current, last, step] = this.range.split(',')
           step = step.trim()
 
@@ -269,7 +274,7 @@ export default {
       layer.isLeaf = true
       layer.zIndex = index
       layer.wmsSource = baseURL
-      layer.isSnapped = isSnapped !== '0' ? true : false
+      layer.isSnapped = snapped
       let op = parseFloat(opacity)
       layer.opacity = isNaN(op) || op > 1 || op < 0 ? 0.75 : op
       layer.visible = isVisible === '0' ? false : true


### PR DESCRIPTION
- LayerTree, LayerConfig and AnimationConfig modifications to adjust menu height to make them fully usable on smaller displays;
- SidePanel modifications to add a secondary scrollbar for the treeview on smaller screens to allow for a min-height on the treeview;
- Snapped GOES Natural preset;
- Removed permalink range check when a layer is snapped;
- Added a missed split on `\` for animation title when a layer is snapped.