### PR TITLE
Changed permalink indices to remember range instead of first

### DIFF
--- a/src/components/GlobalConfigs/Share/PermaLink.vue
+++ b/src/components/GlobalConfigs/Share/PermaLink.vue
@@ -243,18 +243,17 @@ export default {
           let first = this.datetimeRangeSlider[0]
           let current = this.mapTimeSettings.DateIndex
           let last = this.datetimeRangeSlider[1]
+          let range = last - first
           const extentLength = this.mapTimeSettings.Extent.length - 1
-          if (first === extentLength) {
-            first = 'l'
-            current = 'l'
-            last = 'l'
-          } else if (current === extentLength) {
+
+          if (current === extentLength) {
             current = 'l'
             last = 'l'
           } else if (last === extentLength) {
             last = 'l'
           }
-          permalinktemp += `&range=${first},${current},${last},${this.mapTimeSettings.Step}`
+
+          permalinktemp += `&range=${range},${current},${last},${this.mapTimeSettings.Step}`
         }
 
         this.router.replace({

--- a/src/components/Layers/LayerTree.vue
+++ b/src/components/Layers/LayerTree.vue
@@ -193,7 +193,7 @@ export default {
       return [queryUrl, xmlName]
     },
     async requestLayerData(eventData) {
-      const { layer, autoPlay = false, range = undefined } = eventData
+      const { layer, autoPlay = false, rangeValues = undefined } = eventData
       if (this.playState === 'play') {
         this.emitter.emit('toggleAnimation')
       }
@@ -318,7 +318,7 @@ export default {
               layerData,
               source,
               autoPlay,
-              range,
+              rangeValues,
             })
           } catch (err) {
             this.removeLayer(layer.Name)

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -209,7 +209,7 @@ export default {
       if (snapped) {
         this.layerSnapped = true
       }
-      let range
+      let rangeValues
       if (this.layerCount === 0) {
         if (this.play) {
           this.emitter.emit('changeTab')
@@ -217,58 +217,40 @@ export default {
           this.emitter.emit('collapseMenu', true)
         }
         if (this.range !== undefined && !this.layerSnapped) {
-          let [first, current, last, step] = this.range.split(',')
+          let [range, current, last, step] = this.range.split(',')
           step = step.trim()
 
           const isValidIndex = (value) => {
-            return value === 'l' || Number.isInteger(Number(value))
+            if (value === 'l') return true
+            const num = Number(value)
+            return Number.isInteger(num) && num >= 0
           }
           const parseIndex = (value) => {
             return value === 'l' ? 'l' : Number(value)
           }
 
           if (
-            isValidIndex(first) &&
+            isValidIndex(range) &&
             isValidIndex(current) &&
             isValidIndex(last)
           ) {
-            first = parseIndex(first)
+            range = parseIndex(range)
             current = parseIndex(current)
             last = parseIndex(last)
+
+            if (range === 'l') {
+              range = 0
+            }
+
+            rangeValues = [range, current, last, step]
             try {
               // Attempt Duration.fromISO to make sure the step is valid
               Duration.fromISO(step)
-              let rangeValid = false
-
-              const compareValues = (a, b) => {
-                if (a === 'l' && b === 'l') return 0
-                if (a === 'l') return 1
-                if (b === 'l') return -1
-                return a - b
-              }
-
-              if (
-                compareValues(first, current) <= 0 &&
-                compareValues(current, last) <= 0
-              ) {
-                // Also ensure numeric values are >= 0
-                const numericValues = [first, current, last].filter(
-                  (v) => v !== 'l',
-                )
-                if (numericValues.every((v) => v >= 0)) {
-                  rangeValid = true
-                }
-              }
-              if (rangeValid) {
-                range = [first, current, last, step]
-              } else {
-                range = undefined
-              }
             } catch {
-              range = undefined
+              rangeValues = undefined
             }
           } else {
-            range = undefined
+            rangeValues = undefined
           }
         }
       }
@@ -292,7 +274,7 @@ export default {
       this.emitter.emit('permaLinkLayer', {
         layer,
         autoPlay,
-        range,
+        rangeValues,
       })
     },
     findInTree(items, key) {


### PR DESCRIPTION
Permalink "range" parameter now contains `range,current,last,step` instead of `first,current,last,step`. This change was made because remembering the exact first index would sometimes cause the loaded permalink to contain 1 more or 1 fewer timestep depending on when layers are updating. The important part here is to remember the range, not the exact indices.

The reverse problem has also been fixed the same way, where if `last - range` makes the first index be smaller than 0, the "last" will be changed to be sure to keep the range (or entire range if it's now somehow bigger than the full range).