### PR TITLE
Added boradcast channels to change theme and language from an iframe

### DIFF
--- a/src/components/GlobalConfigs/LanguageSelect.vue
+++ b/src/components/GlobalConfigs/LanguageSelect.vue
@@ -14,6 +14,19 @@
 <script>
 export default {
   inject: ['store'],
+  data() {
+    return {
+      channel: new BroadcastChannel('language-channel'),
+    }
+  },
+  mounted() {
+    this.channel.addEventListener('message', this.checkLang)
+    this.channel.postMessage({ type: 'get-language' })
+  },
+  beforeUnmount() {
+    this.channel.removeEventListener('message', this.checkLang)
+    this.channel.close()
+  },
   methods: {
     changeLang() {
       if (this.$i18n.locale === 'en') {
@@ -25,6 +38,16 @@ export default {
       }
       localStorage.setItem('user-lang', this.$i18n.locale)
       this.emitter.emit('localeChange')
+    },
+    checkLang(event) {
+      if (event.data.type === 'language-change') {
+        const requestedLang = event.data.language
+        const currentLang = this.$i18n.locale
+
+        if (requestedLang !== currentLang) {
+          this.changeLang()
+        }
+      }
     },
   },
   computed: {


### PR DESCRIPTION
Broadcast channels added so an iframe can send messages to toggle language and theme.
  - AniMet first sends a request in the channel so the parent app can answer immediately what theme and language it is currently expecting;
  - AniMet then keeps an event listener for changes inside the parent app itself (the parent needs to send the update by itself whenever it changes it).

Example snippet to use inside parent container to receive AniMet request:
```
this.channel.addEventListener('message', (event) => {
  if (event.data.type === 'get-theme') {
    this.channel.postMessage({
      type: 'theme-change',
      theme: this.currentTheme
    })
  }
})
```
Otherwise simply use the `postMessage` command whenever you need to change it:
```
this.channel.postMessage({
  type: 'theme-change',
  theme: this.currentTheme
})
```
Same thing with language selection.