### PR TITLE
Fixed lock so it works through multiple instances

### DIFF
--- a/src/components/Composables/TreeNode.vue
+++ b/src/components/Composables/TreeNode.vue
@@ -123,10 +123,12 @@ const presetSelected = (node) => {
   )
 }
 
-const multiAddLock = ref(false)
+const multiAddLock = computed(() => store.getMultiAddLock)
+const setMultiAddLock = (value) => store.setMultiAddLock(value)
+
 const handleMultiAdd = (node) => {
   if (!multiAddLock.value) {
-    multiAddLock.value = true
+    setMultiAddLock(true)
     const selected = presetSelected(node)
     const nodeChildren = node.children.map((child) => child.Name)
 
@@ -158,7 +160,7 @@ const handleMultiAdd = (node) => {
       }
     }
     setTimeout(() => {
-      multiAddLock.value = false
+      setMultiAddLock(false)
     }, 500)
   }
 }

--- a/src/components/Map/MapCanvas.vue
+++ b/src/components/Map/MapCanvas.vue
@@ -491,7 +491,7 @@ export default {
         if (this.isAnimating && this.playState !== 'play') return
         const url = e.target.getUrl()
         const [key, values] = Object.entries(this.wmsSources).find(
-          ([key, value]) => key !== 'Presets' && value.url === url,
+          ([key, value]) => key !== 'Presets' && value.urls.includes(url),
         )
         let layerName
         if (values['source_validation']) {

--- a/src/stores/store.js
+++ b/src/stores/store.js
@@ -100,6 +100,7 @@ export const useStore = defineStore('store', {
     modelRunMessages: null,
     MP4ProgressPercent: 0,
     MP4URL: null,
+    multiAddLock: false,
     outputDate: null,
     outputFormat: 'MP4',
     outputSize: null,
@@ -154,6 +155,7 @@ export const useStore = defineStore('store', {
     getModelRunMessages: (state) => state.modelRunMessages,
     getMP4ProgressPercent: (state) => state.MP4ProgressPercent,
     getMP4URL: (state) => state.MP4URL,
+    getMultiAddLock: (state) => state.multiAddLock,
     getOutputDate: (state) => state.outputDate,
     getOutputFormat: (state) => state.outputFormat,
     getOutputSize: (state) => state.outputSize,
@@ -296,6 +298,9 @@ export const useStore = defineStore('store', {
     },
     setMP4URL(URL) {
       this.MP4URL = URL
+    },
+    setMultiAddLock(locked) {
+      this.multiAddLock = locked
     },
     setOutputDate(newOutputDate) {
       this.outputDate = newOutputDate


### PR DESCRIPTION
- The `multiAddLock` wasn't working properly with the presets, it was only stopping the same preset from being spam clicked, not different presets one after the other;
- Fixed url -> urls in the error handler after the multi-source changes for the Others section.