### PR TITLE
Fixed ECMWF wrong projection error message

### DIFF
--- a/src/components/Time/ErrorManager.vue
+++ b/src/components/Time/ErrorManager.vue
@@ -311,7 +311,8 @@ export default {
           )
         } else if (
           'code' in attrs &&
-          attrs['code'].nodeValue === 'InvalidSRS'
+          (attrs['code'].nodeValue === 'InvalidSRS' ||
+            attrs['code'].nodeValue === 'InvalidCRS')
         ) {
           this.emitter.emit('removeLayer', layer)
           this.expiredSnackBarMessage = this.t('InvalidSRS', {


### PR DESCRIPTION
Apparently ECMWF layers use the error code `InvalidCRS` and not `InvalidSRS` so added that option as well to get proper error message.