### PR TITLE
Open config panel on permalink load

### DIFF
--- a/src/components/GlobalConfigs/MapCustomizations/CustomizationMenu.vue
+++ b/src/components/GlobalConfigs/MapCustomizations/CustomizationMenu.vue
@@ -71,7 +71,7 @@ export default {
         this.menuOpen = !this.menuOpen
         this.store.setMenusOpen(this.menuOpen)
         if (this.menuOpen) {
-          this.emitter.emit('collapseMenu', false)
+          this.emitter.emit('collapseMenu')
         }
       },
     },

--- a/src/components/Map/SidePanel.vue
+++ b/src/components/Map/SidePanel.vue
@@ -160,22 +160,13 @@ export default {
         }, 250)
       }
     },
-    onChangeTab() {
-      if (this.tab === 0 && this.$mapLayers.arr.length !== 0) this.tab = 1
+    onChangeTab(force = false) {
+      if (force) {
+        this.tab = 1
+      } else if (this.tab === 0 && this.$mapLayers.arr.length !== 0)
+        this.tab = 1
     },
-    onCollapseMenu(permalinkSetup) {
-      if (permalinkSetup) {
-        var unwatch = this.$watch(
-          'layersLength',
-          (_, oldVal) => {
-            if (oldVal !== undefined) {
-              this.tab = 1
-              unwatch()
-            }
-          },
-          { immediate: true },
-        )
-      }
+    onCollapseMenu() {
       if (!this.buttonShown) {
         this.buttonShown = true
         this.menuOpen = false

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -220,11 +220,7 @@ export default {
       }
       let rangeValues
       if (this.layerCount === 0) {
-        if (this.play) {
-          this.emitter.emit('changeTab')
-        } else {
-          this.emitter.emit('collapseMenu', true)
-        }
+        this.emitter.emit('changeTab', true)
         if (this.range !== undefined && !this.layerSnapped) {
           let [range, current, last, step] = this.range.split(',')
           step = step.trim()


### PR DESCRIPTION
- Added `force` option to always switch to layers configuration panel when loading from a permalink as long as there's at least one layer;
- The side panel will also stay open now when loading from a permalink;
- Removed `permalinkSetup` handling to close the side panel and switch tab since it's no longer necessary.