### PR TITLE
Remember legend position and size in permalink

### DIFF
--- a/src/components/Composables/DraggableResizable.vue
+++ b/src/components/Composables/DraggableResizable.vue
@@ -10,19 +10,19 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 
 const props = defineProps([
   'initialPosition',
   'resizeDirection',
   'preventDefault',
 ])
-const emit = defineEmits(['checkIntersect'])
+const emit = defineEmits(['checkIntersect', 'updatePermalink'])
 
 const store = inject('store')
 const isAnimating = computed(() => store.getIsAnimating)
 const playState = computed(() => store.getPlayState)
-
+let resizeObserver = null
 const draggableContainer = ref(null)
 
 const positions = ref({
@@ -210,6 +210,7 @@ const closePinchElement = () => {
   ) {
     emit('checkIntersect')
   }
+  emit('updatePermalink')
 }
 
 const closeDragElement = () => {
@@ -223,18 +224,31 @@ const closeDragElement = () => {
   ) {
     emit('checkIntersect')
   }
-}
-
-const onResizeEnd = () => {
-  document.removeEventListener('mouseup', onResizeEnd)
-  emit('checkIntersect')
+  emit('updatePermalink')
 }
 
 onMounted(() => {
   if (props.initialPosition) {
     draggableContainer.value.style.top = props.initialPosition.top
     draggableContainer.value.style.left = props.initialPosition.left
+    if (props.initialPosition.width) {
+      draggableContainer.value.style.width = props.initialPosition.width
+    }
   }
+
+  resizeObserver = new ResizeObserver(() => {
+    if (
+      document.getElementById('animation-rect')?.style.visibility === 'visible'
+    ) {
+      emit('checkIntersect')
+    }
+    emit('updatePermalink')
+  })
+  resizeObserver.observe(draggableContainer.value)
+})
+
+onUnmounted(() => {
+  resizeObserver?.disconnect()
 })
 </script>
 

--- a/src/components/GlobalConfigs/Share/PermaLink.vue
+++ b/src/components/GlobalConfigs/Share/PermaLink.vue
@@ -56,6 +56,12 @@
 
 <script>
 import { isDarkTheme } from '@/components/Composables/isDarkTheme'
+import {
+  getLegendScaleFactor,
+  BASE62,
+  POS_STEPS,
+  W_STEPS,
+} from '@/utils/legendScale'
 import { useRouter, useRoute } from 'vue-router'
 import OLImage from 'ol/layer/Image'
 
@@ -162,6 +168,53 @@ export default {
               const isInterpolated = layer.getSource().getParams().INTERPOLATION
               if (isInterpolated) {
                 styleInfo += '1'
+              }
+
+              const legendEl = document
+                .getElementById(layerName)
+                ?.closest('.draggable-container')
+              if (legendEl && this.activeLegends.includes(layerName)) {
+                const vw = window.innerWidth
+                const vh = window.innerHeight
+                const img = legendEl.querySelector('img')
+                const naturalWidth = img?.naturalWidth
+                const naturalRatio = img?.naturalWidth / img?.naturalHeight
+                const scaleFactor = getLegendScaleFactor(naturalRatio)
+
+                // Center of the legend as % of viewport
+                const cx = Math.max(
+                  0,
+                  Math.min(
+                    100,
+                    Math.round(
+                      ((legendEl.offsetLeft + legendEl.offsetWidth / 2) / vw) *
+                        10000,
+                    ) / 100,
+                  ),
+                )
+                const cy = Math.max(
+                  0,
+                  Math.min(
+                    100,
+                    Math.round(
+                      ((legendEl.offsetTop + legendEl.offsetHeight / 2) / vh) *
+                        10000,
+                    ) / 100,
+                  ),
+                )
+                const w =
+                  naturalWidth > 0
+                    ? Math.min(
+                        500,
+                        Math.round(
+                          (legendEl.offsetWidth / naturalWidth / scaleFactor) *
+                            10000,
+                        ) / 100,
+                      )
+                    : 0
+                if (w > 0) {
+                  styleInfo += '_' + this.encodePos(cx, cy, w)
+                }
               }
 
               const [name, source] = layerName.split('/')
@@ -271,6 +324,18 @@ export default {
 
         return permalinktemp
       }
+    },
+    encodePos(x, y, w) {
+      const xi = Math.round(x * 100)
+      const yi = Math.round(y * 100)
+      const wi = Math.round(w * 100)
+      let n = xi * POS_STEPS * W_STEPS + yi * W_STEPS + wi
+      let result = ''
+      while (n > 0) {
+        result = BASE62[n % 62] + result
+        n = Math.floor(n / 62)
+      }
+      return result.padStart(8, '0')
     },
     prefixLink() {
       return window.location.origin + window.location.pathname

--- a/src/components/Layers/StyleHandler.vue
+++ b/src/components/Layers/StyleHandler.vue
@@ -131,6 +131,11 @@ export default {
       this.emitter.emit('updatePermalink')
     },
   },
+  watch: {
+    menuVisible(newVal) {
+      this.store.setMenusOpen(newVal)
+    },
+  },
   computed: {
     activeLegends() {
       return this.store.getActiveLegends

--- a/src/components/Map/LegendControls.vue
+++ b/src/components/Map/LegendControls.vue
@@ -5,6 +5,7 @@
     :preventDefault="true"
     resizeDirection="horizontal"
     @checkIntersect="checkIntersect"
+    @updatePermalink="emitter.emit('updatePermalink')"
     @dblclick="emitter.emit('openPanel')"
     @click="emit('legend-click', name)"
   >
@@ -33,6 +34,8 @@ import { computed, onMounted, onBeforeUnmount } from 'vue'
 import { getCurrentInstance } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { getLegendScaleFactor } from '@/utils/legendScale'
+
 const { proxy } = getCurrentInstance()
 
 const props = defineProps(['name'])
@@ -47,22 +50,55 @@ const legendIndex = computed(() => store.getLegendIndex)
 
 const checkResize = (event) => {
   const img = event.target
+  const naturalRatio = img.naturalWidth / img.naturalHeight
 
-  const isMobile = window.innerWidth <= 768
+  const vw = window.innerWidth
+  const vh = window.innerHeight
+  const topSafeZone = vw < 960 ? 84 : 40
 
-  let maxWidth = isMobile ? window.innerWidth * 0.25 : window.innerWidth * 0.35
-  let maxHeight = window.innerHeight * 0.7
+  const scaleFactor = getLegendScaleFactor(naturalRatio)
 
+  const maxWidth = vw * 0.9
+  const maxHeight = vh * 0.85
+
+  const layer = proxy.$mapLayers.arr.find(
+    (l) => l.get('layerName') === img.getAttribute('name'),
+  )
+  const savedPos = layer?.get('legendPosition')
   const container = img.closest('.draggable-container')
-  if (container) {
+  if (!container) return
+
+  if (savedPos && savedPos.w > 0) {
+    const targetWidth = (savedPos.w / 100) * img.naturalWidth * scaleFactor
+
     const excessRatio = Math.max(
-      img.naturalWidth / maxWidth,
-      img.naturalHeight / maxHeight,
+      targetWidth / maxWidth,
+      targetWidth / naturalRatio / maxHeight,
     )
-    if (excessRatio > 1) {
-      container.style.width = img.naturalWidth / excessRatio + 'px'
-    }
+    const finalWidth = excessRatio > 1 ? targetWidth / excessRatio : targetWidth
+    container.style.width = `${finalWidth}px`
+
+    const finalHeight = container.offsetHeight
+
+    const left = Math.max(
+      0,
+      Math.min(vw - finalWidth, (savedPos.cx / 100) * vw - finalWidth / 2),
+    )
+    const top = Math.max(
+      topSafeZone,
+      Math.min(vh - finalHeight, (savedPos.cy / 100) * vh - finalHeight / 2),
+    )
+    container.style.left = `${left}px`
+    container.style.top = `${top}px`
+    return
   }
+
+  const scaledWidth = img.naturalWidth * scaleFactor
+  const scaledHeight = img.naturalHeight * scaleFactor
+
+  const excessRatio = Math.max(scaledWidth / maxWidth, scaledHeight / maxHeight)
+  container.style.width =
+    excessRatio > 1 ? `${scaledWidth / excessRatio}px` : `${scaledWidth}px`
 }
 
 const getLegendHidden = computed(() => {
@@ -108,14 +144,22 @@ const getLegendStyle = () => {
 }
 
 const initialPosStyle = () => {
-  const initialX = 8
-  let initialY
-  if (window.innerWidth < 960) {
-    initialY = 100
-  } else {
-    initialY = 50
-  }
   const offset = legendIndex.value.getItemInteger(props.name) * 10
+
+  const layer = proxy.$mapLayers.arr.find(
+    (l) => l.get('layerName') === props.name,
+  )
+  const savedPos = layer?.get('legendPosition')
+
+  if (savedPos && savedPos.w > 5) {
+    return {
+      top: '0px',
+      left: '0px',
+    }
+  }
+
+  const initialX = 8
+  const initialY = window.innerWidth < 960 ? 100 : 50
   return {
     top: `${initialY + offset}px`,
     left: `${initialX + offset}px`,

--- a/src/components/Map/MapCanvas.vue
+++ b/src/components/Map/MapCanvas.vue
@@ -535,6 +535,11 @@ export default {
       } else if (imageLayer.get('layerStyles').length !== 0) {
         this.store.addActiveLegend(imageLayer.get('layerName'))
       }
+      if (Object.hasOwn(layerData, 'legendPosition')) {
+        imageLayer.setProperties({
+          legendPosition: layerData.legendPosition,
+        })
+      }
       if (imageLayer.get('layerIsTemporal')) {
         this.emitter.emit('addTemporalLayer', {
           imageLayer,

--- a/src/utils/legendScale.js
+++ b/src/utils/legendScale.js
@@ -1,0 +1,16 @@
+export function getLegendScaleFactor(naturalRatio) {
+  const vw = window.innerWidth
+  const phoneWidth = 480
+  const desktopWidth = 1024
+  const viewportFactor = Math.max(
+    0,
+    Math.min(1, (vw - phoneWidth) / (desktopWidth - phoneWidth)),
+  )
+  const ratioFactor = Math.max(0, Math.min(1, (naturalRatio - 0.5) / 2))
+  const minScale = 0.4 + ratioFactor * 0.2
+  return minScale + viewportFactor * (1 - minScale)
+}
+export const BASE62 =
+  '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+export const POS_STEPS = 10001
+export const W_STEPS = 50001

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -9,6 +9,7 @@
 <script>
 import localeData from '../locales/importLocaleFiles'
 import proj4 from 'proj4'
+import { BASE62, POS_STEPS, W_STEPS } from '@/utils/legendScale'
 import { Duration } from 'luxon'
 import { register } from 'ol/proj/proj4'
 
@@ -221,6 +222,9 @@ export default {
       let rangeValues
       if (this.layerCount === 0) {
         this.emitter.emit('changeTab', true)
+        if (window.innerWidth < 960) {
+          this.emitter.emit('collapseMenu')
+        }
         if (this.range !== undefined && !this.layerSnapped) {
           let [range, current, last, step] = this.range.split(',')
           step = step.trim()
@@ -269,9 +273,14 @@ export default {
       layer.opacity = isNaN(op) || op > 1 || op < 0 ? 0.75 : op
       layer.visible = isVisible === '0' ? false : true
       if (styleInfo && styleInfo.length > 0) {
-        layer.legendDisplayed = styleInfo[0] === '1' ? true : false
-        if (styleInfo.length > 1 && styleInfo[1] === '1') {
+        const [flags, posToken] = styleInfo.split('_')
+        layer.legendDisplayed = flags[0] === '1'
+        if (flags.length > 1 && flags[1] === '1') {
           layer.layerInterpolated = true
+        }
+        if (posToken) {
+          const { x: cx, y: cy, w } = this.decodePos(posToken)
+          layer.legendPosition = { cx, cy, w }
         }
       } else {
         layer.legendDisplayed = true
@@ -288,6 +297,16 @@ export default {
         autoPlay,
         rangeValues,
       })
+    },
+    decodePos(s) {
+      let n = 0
+      for (const c of s) n = n * 62 + BASE62.indexOf(c)
+      const w = (n % W_STEPS) / 100
+      n = Math.floor(n / W_STEPS)
+      const y = (n % POS_STEPS) / 100
+      n = Math.floor(n / POS_STEPS)
+      const x = n / 100
+      return { x, y, w }
     },
     findInTree(items, key) {
       for (const item of items) {


### PR DESCRIPTION
Legends position and size are now remembered through the permalink:
- The positions are remembered as [cx, cy, w], where [cx, cy] is the center of the image and [w] is the percentage difference of width from the original legend's size from 0 to 500%;
- The precision is 2 decimal places and the numbers are encoded using a `BASE62` encoding in order to minimize the length it takes in the permalink;
- It is located in the permalink in the same location where the `legendDisplayed` and `layerInterpolated` parameters are, separated by an underscore (looks like `11_03dnQ81f`), and because we can check for the `_` it is easily backwards compatible since we can check whether or not the encoding is there;
- The legend positioning will automatically adjust to be below the space taken by the logo and top buttons on any display;
- The legend size will be automatically adjusted on smaller devices to take less space. An automatic linear scaling is applied so that tall legends on phone are reduced to 40% of the legend's permalink size and wide legends reduced to 60% to make sure smaller screens don't get filled with legends. Those factors are not remembered through the permalink and are applied separately so that they are not applied over and over as you refresh a permalink on smaller displays.

Additionnal improvements:
- GFI no longer triggers when clicking out of the legends selection menu;
- Side panel stays closed by default on smaller displays (tablets and phones) so the user isn't greeted with a side panel that covers the entire screen.