### PR TITLE
Multiple intervals and ECMWF caching bugfixes

### DIFF
--- a/src/components/Animation/AnimationCanvas.vue
+++ b/src/components/Animation/AnimationCanvas.vue
@@ -325,6 +325,7 @@ export default {
           driverDate,
           dateArray,
           visibleTLayers[i].get('layerTimeStep'),
+          visibleTLayers[i].get('layerIntervals'),
         )
         visibleTLayers[i].setProperties({
           layerDateIndex: layerDateIndex,

--- a/src/components/Layers/ModelRunHandler.vue
+++ b/src/components/Layers/ModelRunHandler.vue
@@ -111,6 +111,7 @@ export default {
           this.mapTimeSettings.Extent[this.mapTimeSettings.DateIndex],
           newDateArray,
           this.item.get('layerTimeStep'),
+          this.item.get('layerIntervals'),
         )
         this.item.setProperties({
           layerDateIndex: newLayerIndex,

--- a/src/components/Layers/SnappedLayerHandler.vue
+++ b/src/components/Layers/SnappedLayerHandler.vue
@@ -63,7 +63,17 @@
       </v-row>
       <v-row>
         {{ $t('LayerBarStepTooltip') }} :
-        {{ item.get('layerTrueTimeStep') }}
+        <template v-if="item.get('layerIntervals')">
+          {{
+            item
+              .get('layerIntervals')
+              .map((s) => s.iso)
+              .join(' → ')
+          }}
+        </template>
+        <template v-else>
+          {{ item.get('layerTrueTimeStep') || item.get('layerTimeStep') }}
+        </template>
       </v-row>
     </v-container>
   </v-tooltip>

--- a/src/components/Layers/VisibilityHandler.vue
+++ b/src/components/Layers/VisibilityHandler.vue
@@ -78,6 +78,7 @@ export default {
         this.mapTimeSettings.Extent[this.mapTimeSettings.DateIndex],
         imageLayer.get('layerDateArray'),
         imageLayer.get('layerTimeStep'),
+        imageLayer.get('layerIntervals'),
       )
       imageLayer.setProperties({
         layerDateIndex: layerDateIndex,

--- a/src/components/Time/ErrorManager.vue
+++ b/src/components/Time/ErrorManager.vue
@@ -237,10 +237,30 @@ export default {
                 return
               }
             }
+            let newIntervals = layer.get('layerIntervals')
+            if (newIntervals) {
+              const removedIndex = layer.get('layerDateIndex')
+              newIntervals = newIntervals
+                .map((seg) => {
+                  if (seg.endIndex < removedIndex) return seg
+                  if (seg.startIndex > removedIndex) {
+                    return {
+                      ...seg,
+                      startIndex: seg.startIndex - 1,
+                      endIndex: seg.endIndex - 1,
+                    }
+                  }
+                  if (seg.startIndex === seg.endIndex) return null
+                  return { ...seg, endIndex: seg.endIndex - 1 }
+                })
+                .filter(Boolean)
+              if (newIntervals.length <= 1) newIntervals = null
+            }
             let newDefaultTimeIndex = this.findLayerIndex(
               layer.get('layerDefaultTime'),
               newExtent,
               layer.get('layerTimeStep'),
+              newIntervals,
             )
             layer.setProperties({
               layerDateArray: newExtent,
@@ -248,11 +268,13 @@ export default {
                 this.mapTimeSettings.Extent[this.mapTimeSettings.DateIndex],
                 newExtent,
                 layer.get('layerTimeStep'),
+                newIntervals,
               ),
               layerDefaultTime:
                 newDefaultTimeIndex > 0
                   ? newExtent[newDefaultTimeIndex]
                   : newExtent[0],
+              layerIntervals: newIntervals,
               layerStartTime: newExtent[0],
               layerEndTime: newExtent[newExtent.length - 1],
             })
@@ -494,6 +516,7 @@ export default {
           this.mapTimeSettings.Extent[this.mapTimeSettings.DateIndex],
           config.layerDateArray,
           config.layerTimeStep,
+          config.layerIntervals,
         )
         if (!sameMR) {
           layer.getSource().updateParams({
@@ -532,6 +555,7 @@ export default {
           layerEndTime: new Date(config.layerEndTime),
           layerTimeStep: config.layerTimeStep,
           layerTrueTimeStep: config.layerTrueTimeStep,
+          layerIntervals: config.layerIntervals,
         })
         this.expiredSnackBarMessage = this.t('ExpiredTimesteps')
         this.timeoutDuration = 6000

--- a/src/components/Time/TimeControls.vue
+++ b/src/components/Time/TimeControls.vue
@@ -238,6 +238,7 @@ export default {
         layerEndTime: layerEndTime,
         layerTimeStep: config.layerTimeStep,
         layerTrueTimeStep: config.layerTrueTimeStep,
+        layerIntervals: config.layerIntervals,
       })
       this.store.addTimestep(imageLayer.get('layerTimeStep'))
       if (layerData.isSnapped) {
@@ -253,6 +254,7 @@ export default {
           this.mapTimeSettings.Extent[this.mapTimeSettings.DateIndex],
           imageLayer.get('layerDateArray'),
           imageLayer.get('layerTimeStep'),
+          imageLayer.get('layerIntervals'),
         )
         imageLayer.setProperties({
           layerDateIndex: layerDateIndex,
@@ -348,6 +350,7 @@ export default {
             mapTime,
             dateArray,
             layer.get('layerTimeStep'),
+            layer.get('layerIntervals'),
           )
           layer.setProperties({
             layerDateIndex: layerDateIndex,
@@ -603,6 +606,7 @@ export default {
                     globalTime,
                     dateArray,
                     layer.get('layerTimeStep'),
+                    layer.get('layerIntervals'),
                   )
 
                   if (layerTargetIndex >= 0) {
@@ -624,6 +628,7 @@ export default {
                     globalTime,
                     dateArray,
                     layer.get('layerTimeStep'),
+                    layer.get('layerIntervals'),
                   )
 
                   if (layerTargetIndex >= 0) {
@@ -647,6 +652,7 @@ export default {
                   globalTime,
                   dateArray,
                   layer.get('layerTimeStep'),
+                  layer.get('layerIntervals'),
                 )
 
                 if (layerTargetIndex >= 0) {
@@ -666,6 +672,7 @@ export default {
                   globalTimeBackward,
                   dateArray,
                   layer.get('layerTimeStep'),
+                  layer.get('layerIntervals'),
                 )
 
                 if (layerTargetIndexBackward >= 0) {
@@ -700,15 +707,25 @@ export default {
         )
       }
 
+      const rawUrl = layer.getSource().getUrl()
+      const [baseUrl, existingQuery] = rawUrl.split('?') // split off ?token=public
+
+      // Merge existing query params into urlParams before sorting
+      if (existingQuery) {
+        new URLSearchParams(existingQuery).forEach((value, key) => {
+          if (!(key in urlParams)) urlParams[key] = value
+        })
+      }
+
       const queryString = Object.keys(urlParams)
-        .sort()
+        .sort((a, b) => a.localeCompare(b))
         .map(
           (key) =>
             `${encodeURIComponent(key)}=${encodeURIComponent(urlParams[key])}`,
         )
         .join('&')
 
-      const wmsUrl = `${layer.getSource().getUrl()}?${queryString}`
+      const wmsUrl = `${baseUrl}?${queryString}`
 
       await this.tileCache.preload(layerName, wmsUrl)
     },

--- a/src/mixins/datetimeManipulations.js
+++ b/src/mixins/datetimeManipulations.js
@@ -1,4 +1,4 @@
-import { DateTime, Interval } from 'luxon'
+import { DateTime, Duration, Interval } from 'luxon'
 import parseDuration from '../assets/parseHelper'
 
 export default {
@@ -124,7 +124,8 @@ export default {
       this.emitter.emit('updatePermalink')
     },
     createTimeLayerConfig(Dimension_time) {
-      let [dateArrayFormat, trueStep, Step] = this.findFormat(Dimension_time)
+      let [dateArrayFormat, trueStep, Step, intervals] =
+        this.findFormat(Dimension_time)
       if (dateArrayFormat === null) {
         return null
       }
@@ -135,32 +136,53 @@ export default {
         layerEndTime: dateArrayFormat[0][dateArrayFormat[0].length - 1],
         layerTimeStep: Step,
         layerTrueTimeStep: trueStep,
+        layerIntervals: intervals,
       }
     },
-    findLayerIndex(date, layerDateArr, step) {
+    findLayerIndex(date, layerDateArr, step, intervals = null) {
       let start = 0
       let end = layerDateArr.length - 1
+
       if (date <= layerDateArr[start]) {
-        if (date < layerDateArr[start]) {
-          return -1
-        } else {
-          return 0
-        }
+        return date < layerDateArr[start] ? -1 : 0
       } else if (date >= layerDateArr[end]) {
-        if (date >= parseDuration(step).add(layerDateArr[end])) {
+        const lastStep = intervals ? intervals[intervals.length - 1].iso : step
+        if (date >= parseDuration(lastStep).add(layerDateArr[end])) {
           return -2
         } else {
           return end
         }
       }
+
+      let searchStart = 0
+      let searchEnd = end
+      let activeStep = step
+
+      if (intervals) {
+        for (let s = 0; s < intervals.length; s++) {
+          const isLastSeg = s === intervals.length - 1
+          const nextSegStartDate = isLastSeg
+            ? null
+            : layerDateArr[intervals[s + 1].startIndex]
+
+          if (nextSegStartDate === null || date < nextSegStartDate) {
+            activeStep = intervals[s].iso
+            searchStart = intervals[s].startIndex
+            searchEnd = intervals[s].endIndex
+            break
+          }
+        }
+      }
+
+      start = searchStart
+      end = searchEnd
       while (start <= end) {
-        let mid = Math.floor((start + end) / 2)
-        let dateCeiling = parseDuration(step === 'PT0H' ? 'PT1H' : step).add(
-          layerDateArr[mid],
-        )
-        // If date is found
-        if (date >= layerDateArr[mid] && date < dateCeiling) return mid
-        else if (date >= dateCeiling) start = mid + 1
+        const mid = Math.floor((start + end) / 2)
+        const ceiling = parseDuration(
+          activeStep === 'PT0H' ? 'PT1H' : activeStep,
+        ).add(layerDateArr[mid])
+        if (date >= layerDateArr[mid] && date < ceiling) return mid
+        else if (date >= ceiling) start = mid + 1
         else end = mid - 1
       }
       return -3
@@ -187,17 +209,48 @@ export default {
         // transform into single dates since there are likely multiple formats
         case /^[^,]*\/[^,]*\/[^,]*(?:,[^,]*\/[^,]*\/[^,]*)*$/.test(dateRange): {
           let dateArray = []
-          let dateRanges = dateRange.split(',')
-          for (let i = 0; i < dateRanges.length; i++) {
-            let [startDateStr, endDateStr, interval] = dateRanges[i].split('/')
-            dateArray = dateArray.concat(
-              this.getDateArray(startDateStr, endDateStr, interval)[0],
+          let segments = []
+          let format = 'ISO'
+          let minIso = null
+
+          for (const range of dateRange.split(',')) {
+            const [startDateStr, endDateStr, interval] = range.split('/')
+            const [chunk, chunkFormat] = this.getDateArray(
+              startDateStr,
+              endDateStr,
+              interval,
             )
+            if (chunkFormat !== 'ISO') format = chunkFormat
+
+            const effectiveIso = interval === 'PT0H' ? 'PT1H' : interval
+            if (
+              minIso === null ||
+              Duration.fromISO(effectiveIso).toMillis() <
+                Duration.fromISO(minIso).toMillis()
+            ) {
+              minIso = effectiveIso
+            }
+
+            const lastSeg = segments[segments.length - 1]
+            if (lastSeg && lastSeg.iso === effectiveIso) {
+              lastSeg.endIndex = dateArray.length + chunk.length - 1
+            } else {
+              segments.push({
+                iso: effectiveIso,
+                startIndex: dateArray.length,
+                endIndex: dateArray.length + chunk.length - 1,
+              })
+            }
+            dateArray = dateArray.concat(chunk)
           }
-          const arrayToCSV = dateArray
-            .map((dateObj) => dateObj.toISOString())
-            .join(',')
-          return this.findFormat(arrayToCSV)
+
+          const hasMultipleSteps = segments.length > 1
+          return [
+            [dateArray, format],
+            null,
+            minIso,
+            hasMultipleSteps ? segments : null,
+          ]
         }
         // special case mostly for ECMWF that looks like start1,date2/end1/step,start2/end2/step2
         // so this is simply to put start1 inside the first interval
@@ -248,25 +301,86 @@ export default {
       }
 
       let interval
+      let intervals = null
       if (dateRange.length > 1) {
+        const dateRangeLength = dateRange.length
+        const durationSet = new Set()
+
         let probeStart = Interval.fromDateTimes(
           DateTime.fromISO(dateRange[0], { zone: 'utc' }),
           DateTime.fromISO(dateRange[1], { zone: 'utc' }),
         ).toDuration(['years', 'months', 'hours', 'minutes'])
-        let probeNext
-        const dateRangeLength = dateRange.length
+        durationSet.add(probeStart.toISO())
+
         for (let i = 2; i < dateRangeLength; i++) {
-          probeNext = Interval.fromDateTimes(
+          const probeNext = Interval.fromDateTimes(
             DateTime.fromISO(dateRange[i - 1], { zone: 'utc' }),
             DateTime.fromISO(dateRange[i], { zone: 'utc' }),
           ).toDuration(['years', 'months', 'hours', 'minutes'])
-          if (!probeStart.equals(probeNext)) {
-            if (probeNext.toMillis() < probeStart.toMillis()) {
-              probeStart = probeNext
-            }
+          durationSet.add(probeNext.toISO())
+          if (
+            !probeStart.equals(probeNext) &&
+            probeNext.toMillis() < probeStart.toMillis()
+          ) {
+            probeStart = probeNext
           }
         }
-        interval = probeStart.toISO()
+
+        const allMs = Array.from(durationSet).map((iso) =>
+          Duration.fromISO(iso).toMillis(),
+        )
+        const minMs = Math.min(...allMs)
+        const maxMs = Math.max(...allMs)
+        const jitterThreshold = 0.1
+
+        if ((maxMs - minMs) / minMs < jitterThreshold) {
+          // Special case for small jitter around a single step,
+          // treat as one interval with the smallest step as the interval
+          interval = Duration.fromMillis(Math.floor(minMs / 1000) * 1000)
+            .shiftTo('days', 'hours', 'minutes', 'seconds')
+            .toISO()
+          intervals = null
+        } else {
+          // Meaningfully distinct steps — build segments
+          interval = Duration.fromMillis(Math.floor(minMs / 1000) * 1000)
+            .shiftTo('days', 'hours', 'minutes', 'seconds')
+            .toISO()
+
+          const segments = []
+          let segStartIndex = 0
+          let segIso = Interval.fromDateTimes(
+            DateTime.fromISO(dateRange[0], { zone: 'utc' }),
+            DateTime.fromISO(dateRange[1], { zone: 'utc' }),
+          )
+            .toDuration(['years', 'months', 'hours', 'minutes'])
+            .toISO()
+
+          for (let i = 2; i < dateRangeLength; i++) {
+            const currentIso = Interval.fromDateTimes(
+              DateTime.fromISO(dateRange[i - 1], { zone: 'utc' }),
+              DateTime.fromISO(dateRange[i], { zone: 'utc' }),
+            )
+              .toDuration(['years', 'months', 'hours', 'minutes'])
+              .toISO()
+
+            if (currentIso !== segIso) {
+              segments.push({
+                iso: segIso,
+                startIndex: segStartIndex,
+                endIndex: i - 2,
+              })
+              segStartIndex = i - 1
+              segIso = currentIso
+            }
+          }
+          segments.push({
+            iso: segIso,
+            startIndex: segStartIndex,
+            endIndex: dateRangeLength - 1,
+          })
+
+          intervals = segments.length > 1 ? segments : null
+        }
       } else {
         if (format === 'ISO') {
           interval = 'PT1H'
@@ -277,7 +391,7 @@ export default {
         }
       }
 
-      return [[dateArray, format], null, interval]
+      return [[dateArray, format], null, interval, intervals]
     },
     getProperDateString(date, dateFormat) {
       if (dateFormat === 'year') {


### PR DESCRIPTION
Changed time handling to remember multiple intervals if layers contain multiple:
- Tooltip changed to reflect the multiple intervals inside the snap layer tooltip;
- When mixing layers that change from PT1H to PT3H with layers that contain only PT1H on the entire range, the PT1H will continue updating every hour and the one that is now PT3H will still be displayed for 3h at a time instead of disappearing for hours 1 and 2 (current behavior).

Fixed ECMWF caching:
- ECMWF's base URL needs to contain `?token=public`, therefore when I tried to rebuild the URL for the cache I would add another `?` symbol to put the URL params coming after, which gave an incorrect URL;
- Needed to change the sorting also so that `?token=public` would appear correctly in alphabetical order to match request with cache.