### PR TITLE
Fixed expanding submenu not flipping directions in GFI

### DIFF
--- a/src/components/Map/GetFeatureInfo.vue
+++ b/src/components/Map/GetFeatureInfo.vue
@@ -439,8 +439,11 @@ export default {
       }
     },
     popupFocus() {
-      this.$nextTick(() => {
+      this.$nextTick(async () => {
         if (this.overlay !== null) {
+          if (this.eventGFI) {
+            await this.applyOrientation(this.eventGFI.event)
+          }
           this.adjustPopupPosition()
         }
       })


### PR DESCRIPTION
The GFI direction fix was only working when the click event fired, but opening the sub menus inside would not re-trigger the direction check if the popup was now expanding outside of the portion of the map that could be panned.
Fixed so that now the direction flip is checked on sub-menu open/close as well.