### PR TITLE
Fixed Drag and Drop broken because of interpolation check

### DIFF
--- a/src/components/Layers/LayerConfiguration.vue
+++ b/src/components/Layers/LayerConfiguration.vue
@@ -84,7 +84,7 @@
                 <interpolation-handler
                   v-if="
                     Object.values(wmsSources)[item.get('layerWmsIndex')]
-                      .hasInterpolation
+                      ?.hasInterpolation
                   "
                   :item="item"
                   :color="isSnapped(item.get('layerName'))"


### PR DESCRIPTION
The `hasInterpolation` check works with every source that we have added in AniMet, except drag and drop layers don't have a source and therefore the code would fail saying `Cannot read properties of undefined (reading 'hasInterpolation')`.