### PR TITLE
enable silent auto refresh of non time-enabled layers

### DIFF
--- a/scripts/wms_sources_configs.py
+++ b/scripts/wms_sources_configs.py
@@ -1,5 +1,10 @@
 import os
 
+# Non-time-enabled layers whose underlying data changes frequently. Animet forces
+# a GetMap re-request for these once a minute so the map doesn't go stale; time
+# enabled layers are ignored since they already refresh via their time dimension.
+GEOMET_WEATHER_REFRESH_LAYERS = ["Current-Alerts"]
+
 wms_sources = {
     "Presets": {
         "urls": [os.environ.get("GEOMET_WEATHER_NIGHTLY_URL", default="https://geo.weather.gc.ca/geomet")],
@@ -12,6 +17,7 @@ wms_sources = {
         "version": "1.3.0",
         "display": True,
         "hasInterpolation": True,
+        "refresh_layers": GEOMET_WEATHER_REFRESH_LAYERS,
     },
     "Climate": {
         "urls": ["https://geo.weather.gc.ca/geomet-climate"],
@@ -24,6 +30,7 @@ wms_sources = {
         "display": os.environ.get("ANIMET_NIGHTLY", default=False),
         "source_validation": True,
         "hasInterpolation": True,
+        "refresh_layers": GEOMET_WEATHER_REFRESH_LAYERS,
     },
     "ClimateNightly": {
         "urls": [os.environ.get("GEOMET_CLIMATE_NIGHTLY_URL", default="")],
@@ -37,6 +44,7 @@ wms_sources = {
         "display": os.environ.get("ANIMET_NIGHTLY", default=False),
         "source_validation": True,
         "hasInterpolation": True,
+        "refresh_layers": GEOMET_WEATHER_REFRESH_LAYERS,
     },
     "ClimateDev": {
         "urls": [os.environ.get("GEOMET_CLIMATE_DEV_URL", default="")],
@@ -50,6 +58,7 @@ wms_sources = {
         "display": os.environ.get("ANIMET_NIGHTLY", default=False),
         "source_validation": True,
         "hasInterpolation": True,
+        "refresh_layers": GEOMET_WEATHER_REFRESH_LAYERS,
     },
     "ClimateStage": {
         "urls": [os.environ.get("GEOMET_CLIMATE_STAGE_URL", default="")],

--- a/src/components/Animation/CreateAnimation.vue
+++ b/src/components/Animation/CreateAnimation.vue
@@ -170,6 +170,7 @@ export default {
       this.store.setMP4URL(null)
       this.store.setImgURL(null)
       this.store.setIsAnimating(true)
+      this.store.setIsGeneratingAnimation(true)
       this.generating = true
       this.$mapCanvas.mapObj.updateSize()
 
@@ -335,6 +336,7 @@ export default {
           }
           if (this.pendingErrorResolution) {
             this.generating = false
+            this.store.setIsGeneratingAnimation(false)
             return
           }
           await this.composeCanvas(
@@ -373,6 +375,7 @@ export default {
       this.encoder.finalize()
 
       this.store.setIsAnimating(false)
+      this.store.setIsGeneratingAnimation(false)
       if (this.generating) {
         if (this.MP4Length === 1) {
           const binaryData = atob(this.imgURL.split(',')[1])

--- a/src/components/Map/MapCanvas.vue
+++ b/src/components/Map/MapCanvas.vue
@@ -451,6 +451,9 @@ export default {
     },
     async buildLayer(eventData) {
       const { layerData, source: wmsSource, autoPlay, rangeValues } = eventData
+      const sourceKey = Object.keys(this.wmsSources)[layerData.wmsIndex]
+      const refreshLayers = this.wmsSources[sourceKey]?.['refresh_layers'] ?? []
+      const needsRefresh = refreshLayers.includes(layerData.Name.split('/')[0])
       let imageLayer = null
       imageLayer = new OLImage({
         source: new ImageWMS({
@@ -477,6 +480,7 @@ export default {
           : 1,
         layerIsTemporal: layerData.isTemporal,
         layerName: layerData.Name,
+        layerNeedsRefresh: needsRefresh,
         layerStyles: layerData.Style,
         layerVisibilityOn: Object.hasOwn(layerData, 'visible')
           ? layerData.visible
@@ -497,9 +501,15 @@ export default {
       this.setLayerZIndex(imageLayer)
 
       imageLayer.getSource().on('imageloadstart', () => {
-        this.loading += 1
+        const silent = imageLayer.get('layerSilentRefresh') === true
+        imageLayer.setProperties({
+          layerSilentRefresh: false,
+          layerSilentLoad: silent,
+        })
+        if (!silent) this.loading += 1
       })
       imageLayer.getSource().on(['imageloadend', 'imageloaderror'], () => {
+        if (imageLayer.get('layerSilentLoad')) return
         this.loading -= 1
       })
 

--- a/src/components/Time/AutoRefresh.vue
+++ b/src/components/Time/AutoRefresh.vue
@@ -9,6 +9,7 @@ export default {
   data() {
     return {
       interval: setInterval(this.fetchLayerData, 90000),
+      refreshInterval: setInterval(this.refreshMarkedLayers, 60000),
       iterationCounter: 0,
       layers: [],
     }
@@ -43,7 +44,11 @@ export default {
         this.iterationCounter = 0
         if (this.isAnimating && this.playState !== 'play') return
         this.$mapLayers.arr.forEach((layer) => {
-          if (layer instanceof OLImage && !layer.get('layerIsTemporal')) {
+          if (
+            layer instanceof OLImage &&
+            !layer.get('layerIsTemporal') &&
+            !layer.get('layerNeedsRefresh')
+          ) {
             layer.getSource().updateParams({
               t: new Date().getTime(),
             })
@@ -136,13 +141,32 @@ export default {
     onTimeLayerRemoved(layer) {
       this.layers = this.layers.filter((l) => l !== layer.get('layerName'))
     },
+    refreshMarkedLayers() {
+      if (this.isGeneratingAnimation) return
+      this.$mapLayers.arr.forEach((layer) => {
+        if (
+          !layer.get('layerNeedsRefresh') ||
+          layer.get('layerIsTemporal') ||
+          !layer.getVisible()
+        )
+          return
+        layer.set('layerSilentRefresh', true)
+        layer.getSource().updateParams({
+          t: new Date().getTime(),
+        })
+      })
+    },
     stopPolling() {
       clearInterval(this.interval)
+      clearInterval(this.refreshInterval)
     },
   },
   computed: {
     isAnimating() {
       return this.store.getIsAnimating
+    },
+    isGeneratingAnimation() {
+      return this.store.getIsGeneratingAnimation
     },
     playState() {
       return this.store.getPlayState

--- a/src/stores/store.js
+++ b/src/stores/store.js
@@ -61,6 +61,7 @@ export const useStore = defineStore('store', {
     intersectDict: {},
     isAnimating: false,
     isAnimationReversed: false,
+    isGeneratingAnimation: false,
     isFullSize: false,
     isLooping: true,
     isReversed: false,
@@ -223,6 +224,7 @@ export const useStore = defineStore('store', {
     getIntersectMessageDisplayed: (state) => state.intersectDict,
     getIsAnimating: (state) => state.isAnimating,
     getIsAnimationReversed: (state) => state.isAnimationReversed,
+    getIsGeneratingAnimation: (state) => state.isGeneratingAnimation,
     getIsReversed: (state) => state.isReversed,
     getLegendIndex: (state) => state.legendIndex,
     getMapTimeSettings: (state) => state.mapTimeSettings,
@@ -333,6 +335,9 @@ export const useStore = defineStore('store', {
     },
     setIsAnimating(newStatus) {
       this.isAnimating = newStatus
+    },
+    setIsGeneratingAnimation(newStatus) {
+      this.isGeneratingAnimation = newStatus
     },
     setIsAnimationReversed(isReversed) {
       this.isAnimationReversed = isReversed


### PR DESCRIPTION
This PR ensures that non time-enabled layers whose data changes frequently are refreshed every minute, instead of waiting for the existing ~9 minute refresh sweep.

Layers like `Current-Alerts` could previously show stale data for several minutes.

## Changes

- **`scripts/wms_sources_configs.py`** — new optional per-source `refresh_layers` key, currently `["Current-Alerts"]` on the GeoMet-Weather sources.
- **`MapCanvas.vue`** — tags matching layers with `layerNeedsRefresh` when they're built.
- **`AutoRefresh.vue`** — new 60s timer that re-requests those layers. They're excluded from the old ~9 minute sweep so they don't refresh twice.
- **`store.js` / `CreateAnimation.vue`** — new `isGeneratingAnimation` flag so refreshes pause during an animation export, but not while an animation is merely paused.

Time-enabled layers are unaffected.